### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: giap-web-ci
 
+permissions:
+  contents: read
+
 on:
   push:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: giap-web-ci
 
 permissions:
   contents: read
+  packages: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-pupils/security/code-scanning/1](https://github.com/DFE-Digital/get-information-about-pupils/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow primarily involves reading repository contents, running tests, and uploading artifacts. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
