### PR TITLE
Potential fix for code scanning alert no. 6: Log entries created from user input

### DIFF
--- a/DfE.GIAP.All/DfE.GIAP.Service/ApiProcessor/ApiService.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Service/ApiProcessor/ApiService.cs
@@ -51,7 +51,8 @@ namespace DfE.GIAP.Service.ApiProcessor
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Exception getting data '{ex.Message}' from {url.AbsoluteUri}.");
+                var sanitizedUrl = url.AbsoluteUri.Replace("\n", "").Replace("\r", "");
+                _logger.LogError(ex, $"Exception getting data '{ex.Message}' from {sanitizedUrl}.");
             }
 
             return default;


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-pupils/security/code-scanning/6](https://github.com/DFE-Digital/get-information-about-pupils/security/code-scanning/6)

To fix the issue, we need to sanitize the `url.AbsoluteUri` value before including it in the log entry. Specifically:
1. Remove any newline characters (`\n` or `\r`) from the `url.AbsoluteUri` to prevent log forging.
2. Ensure that the sanitized value is used in the log message.

The fix will involve replacing the log statement on line 54 in `DfE.GIAP.All/DfE.GIAP.Service/ApiProcessor/ApiService.cs` with a sanitized version of `url.AbsoluteUri`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
