### PR TITLE
Add GitHub Actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/DfE.GIAP.All"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot can be configured to keep GitHub Actions up to date.

This PR updates the dependabot config to do so, and follows the same "daily" schedule as per the other pre-existing ecosystem configs.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot