### PR TITLE
dont scan with sonar if dependabot is actor

### DIFF
--- a/.github/workflows/web-application-cicd.yml
+++ b/.github/workflows/web-application-cicd.yml
@@ -61,6 +61,8 @@ jobs:
           java-version: '17'
 
       - name: Start SonarCloud Scanner
+        # TODO fix in https://github.com/DFE-Digital/get-information-about-pupils/issues/17#issuecomment-2994486283
+        if: github.actor != 'dependabot[bot]'
         shell: bash
         run: |
           dotnet tool run dotnet-sonarscanner begin \
@@ -117,7 +119,8 @@ jobs:
           path: ${{ env.SOLUTION_DIRECTORY }}/coverlet/reports/*
 
       - name: End SonarCloud Scanner
-        if: always()
+        # TODO fix in https://github.com/DFE-Digital/get-information-about-pupils/issues/17#issuecomment-2994486283
+        if: ${{ github.actor != 'dependabot[bot]' && always() }}
         shell: bash
         run: dotnet tool run dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 


### PR DESCRIPTION
## 📌 Summary

As per #17 this PR disables dependabot which currently fails to build because it runs the SonarScan step, needing SONAR_TOKEN. Due to Dependabots security model repository secrets are not passed to it during execution. Which differs to to GitHub actions. One of the reasons being dependabot could introduce malicious dependancies into our code, like a poisoned cache, which use the tokens maliciously (although it may be a readonly token - dependabot cannot know that)

The solution lies in setting up a GitHub app (acts similar to a fine-grained auth token by the looks of it. 

I think in the interim this solution doesn't run the sonarscan for dependabot PRs. And we'll forward fix to use the GitHub app approach as it only effects dependabot prs, which'll then also remove the need to store `SONAR_TOKEN` as a secret.

--- 

The risk would be package vulnerabilities?

- we have CodeQL running, which should alert us to security vulnerabilities in packages, 
- `main` will trigger after dependabot merges (at which the actions will run the Sonar scan) again package vulnerabilities would be captured.

## 🧪 Changes Made

- [x] Bug fix

## 🧪 How to Test

We'll run the dependabot workflow once this is in `main`

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
