### PR TITLE
Disable nullable for Web proj due to differing behaviour in ModelState with Attributes

### DIFF
--- a/DfE.GIAP.All/DfE.GIAP.Web/DfE.GIAP.Web.csproj
+++ b/DfE.GIAP.All/DfE.GIAP.Web/DfE.GIAP.Web.csproj
@@ -1,7 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>d4e9d00c-c90a-4862-a2de-9e169b13be02</UserSecretsId>
+    <!-- Note: this has been disabled because Web has ViewModels that have [Required()] attributes on its ViewModel Properties.
+        When nullable is enabled it causes different behaviour as ModelState.IsValid() will evaluate to false - as some properties are bound as null than "" and fail the ModelStateValidation-->
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Views\Search\Download\**" />


### PR DESCRIPTION
## 📌 Summary

Errors occuring when ModelState.IsValid is evaluated if Web enables `nullable`, so disabled with a comment.


## 🧪 Changes Made

- [x] Bug fix

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
