### PR TITLE
remove FluentAssertions from Web and Common

### DIFF
--- a/DfE.GIAP.All/DfE.GIAP.Common.Tests/DfE.GIAP.Common.Tests.csproj
+++ b/DfE.GIAP.All/DfE.GIAP.Common.Tests/DfE.GIAP.Common.Tests.csproj
@@ -5,7 +5,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/DfE.GIAP.All/DfE.GIAP.Common.Tests/Validation/DownloadDocumentTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Common.Tests/Validation/DownloadDocumentTests.cs
@@ -1,139 +1,137 @@
 ﻿using DfE.GIAP.Common.Enums;
 using DfE.GIAP.Common.Validation;
 using Xunit;
-using FluentAssertions;
 
-namespace DfE.GIAP.Common.Tests.Validation
+namespace DfE.GIAP.Common.Tests.Validation;
+
+[Trait("Validator", "Download Document")]
+public class DownloadDocumentTests
 {
-    [Trait("Validator", "Download Document")]
-    public class DownloadDocumentTests
+    [Theory]
+    [InlineData(DownloadDataType.EYFSP, 2, 15)]
+    [InlineData(DownloadDataType.EYFSP,10,17)]
+    public void EarlyYearsFoundationStagePupil_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
     {
-        [Theory]
-        [InlineData(DownloadDataType.EYFSP, 2, 15)]
-        [InlineData(DownloadDataType.EYFSP,10,17)]
-        public void EarlyYearsFoundationStagePupil_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType( type, statutoryLowAge,  statutoryHighAge);
-            result.Should().BeTrue();
-        }
+        bool result = DownloadValidation.ValidateDownloadDataType( type, statutoryLowAge,  statutoryHighAge);
+        Assert.True(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.EYFSP, 11, 15)]
-        [InlineData(DownloadDataType.EYFSP, 11, 34)]
-        [InlineData(DownloadDataType.EYFSP, 11, 4)]
-        public void EarlyYearsFoundationStagePupil_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.EYFSP, 11, 15)]
+    [InlineData(DownloadDataType.EYFSP, 11, 34)]
+    [InlineData(DownloadDataType.EYFSP, 11, 4)]
+    public void EarlyYearsFoundationStagePupil_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.KS1, 2, 6)]
-        [InlineData(DownloadDataType.KS1, 12, 17)]
-        public void KeyStageOne_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeTrue();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.KS1, 2, 6)]
+    [InlineData(DownloadDataType.KS1, 12, 17)]
+    public void KeyStageOne_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.True(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.KS1, 1, 15)]
-        [InlineData(DownloadDataType.KS1, 2, 4)]
-        [InlineData(DownloadDataType.KS1, 5, 26)]
-        [InlineData(DownloadDataType.KS1, 10, 7)]
-        public void KeyStageOne_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.KS1, 1, 15)]
+    [InlineData(DownloadDataType.KS1, 2, 4)]
+    [InlineData(DownloadDataType.KS1, 5, 26)]
+    [InlineData(DownloadDataType.KS1, 10, 7)]
+    public void KeyStageOne_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.KS2, 10, 16)]
-        [InlineData(DownloadDataType.KS2, 12, 23)]
-        public void KeyStageTwo_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeTrue();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.KS2, 10, 16)]
+    [InlineData(DownloadDataType.KS2, 12, 23)]
+    public void KeyStageTwo_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.True(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.KS2, 17, 25)]
-        [InlineData(DownloadDataType.KS2, 2, 4)]
-        [InlineData(DownloadDataType.KS2, 15, 26)]
-        [InlineData(DownloadDataType.KS2, 16, 13)]
-        public void KeyStageTwo_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.KS2, 17, 25)]
+    [InlineData(DownloadDataType.KS2, 2, 4)]
+    [InlineData(DownloadDataType.KS2, 15, 26)]
+    [InlineData(DownloadDataType.KS2, 16, 13)]
+    public void KeyStageTwo_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.KS4, 13, 16)]
-        [InlineData(DownloadDataType.KS4, 2, 23)]
-        public void KeyStageFour_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeTrue();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.KS4, 13, 16)]
+    [InlineData(DownloadDataType.KS4, 2, 23)]
+    public void KeyStageFour_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.True(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.KS4, 18, 25)]
-        [InlineData(DownloadDataType.KS4, 2, 4)]
-        [InlineData(DownloadDataType.KS4, 15, 26)]
-        [InlineData(DownloadDataType.KS4, 15, 12)]
-        public void KeyStageFour_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.KS4, 18, 25)]
+    [InlineData(DownloadDataType.KS4, 2, 4)]
+    [InlineData(DownloadDataType.KS4, 15, 26)]
+    [InlineData(DownloadDataType.KS4, 15, 12)]
+    public void KeyStageFour_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.Phonics, 3, 8)]
-        [InlineData(DownloadDataType.Phonics, 7, 23)]
-        public void Phonics_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeTrue();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.Phonics, 3, 8)]
+    [InlineData(DownloadDataType.Phonics, 7, 23)]
+    public void Phonics_Validation_Should_Pass(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.True(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.Phonics, 18, 20)]
-        [InlineData(DownloadDataType.Phonics, 1, 2)]
-        [InlineData(DownloadDataType.Phonics, 4, 26)]
-        [InlineData(DownloadDataType.Phonics, 15, 12)]
-        public void Phonics_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.Phonics, 18, 20)]
+    [InlineData(DownloadDataType.Phonics, 1, 2)]
+    [InlineData(DownloadDataType.Phonics, 4, 26)]
+    [InlineData(DownloadDataType.Phonics, 15, 12)]
+    public void Phonics_Validation_Should_Fail(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadDataType.Phonics, 1, 12)]
-        [InlineData(DownloadDataType.Phonics, 10, 29)]
-        [InlineData(DownloadDataType.Phonics, 12, 26)]
-        [InlineData(DownloadDataType.Phonics, 15, 12)]
-        public void Dafault_Validation_Should_Fail_Because_Out_Of_Range(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadDataType.Phonics, 1, 12)]
+    [InlineData(DownloadDataType.Phonics, 10, 29)]
+    [InlineData(DownloadDataType.Phonics, 12, 26)]
+    [InlineData(DownloadDataType.Phonics, 15, 12)]
+    public void Default_Validation_Should_Fail_Because_Out_Of_Range(DownloadDataType type, int statutoryLowAge, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateDownloadDataType(type, statutoryLowAge, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadUlnDataType.PP, 12)]
-        [InlineData(DownloadUlnDataType.SEN, 12)]
-        public void ValidateUlnDownloadDataType_Should_fail_because_of_out_of_range(DownloadUlnDataType type, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateUlnDownloadDataType(type, statutoryHighAge);
-            result.Should().BeFalse();
-        }
+    [Theory]
+    [InlineData(DownloadUlnDataType.PP, 12)]
+    [InlineData(DownloadUlnDataType.SEN, 12)]
+    public void ValidateUlnDownloadDataType_Should_fail_because_of_out_of_range(DownloadUlnDataType type, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateUlnDownloadDataType(type, statutoryHighAge);
+        Assert.False(result);
+    }
 
-        [Theory]
-        [InlineData(DownloadUlnDataType.PP, 15)]
-        [InlineData(DownloadUlnDataType.SEN, 16)]
-        public void ValidateUlnDownloadDataType_Should_pass_because_in_range(DownloadUlnDataType type, int statutoryHighAge)
-        {
-            var result = DownloadValidation.ValidateUlnDownloadDataType(type, statutoryHighAge);
-            result.Should().BeTrue();
-        }
+    [Theory]
+    [InlineData(DownloadUlnDataType.PP, 15)]
+    [InlineData(DownloadUlnDataType.SEN, 16)]
+    public void ValidateUlnDownloadDataType_Should_pass_because_in_range(DownloadUlnDataType type, int statutoryHighAge)
+    {
+        bool result = DownloadValidation.ValidateUlnDownloadDataType(type, statutoryHighAge);
+        Assert.True(result);
     }
 }

--- a/DfE.GIAP.All/DfE.GIAP.Web.Tests/Controllers/PrePreparedDownloads/PrePreparedDownloadsControllerTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Web.Tests/Controllers/PrePreparedDownloads/PrePreparedDownloadsControllerTests.cs
@@ -1,130 +1,152 @@
-﻿using DfE.GIAP.Common.AppSettings;
-using DfE.GIAP.Common.Helpers.CookieManager;
+﻿using System.Security.Claims;
+using DfE.GIAP.Common.AppSettings;
 using DfE.GIAP.Domain.Models.Common;
 using DfE.GIAP.Service.Common;
 using DfE.GIAP.Service.PreparedDownloads;
 using DfE.GIAP.Web.Controllers.PreparedDownload;
 using DfE.GIAP.Web.Tests.FakeData;
 using DfE.GIAP.Web.ViewModels.PrePreparedDownload;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Moq;
 using NSubstitute;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using Xunit;
 
-namespace DfE.GIAP.Web.Tests.Controllers.PrePreparedDownloads
+namespace DfE.GIAP.Web.Tests.Controllers.PrePreparedDownloads;
+
+[Trait("PreparedDownloads", "PreparedDownloads Controller Unit Tests")]
+public class PrePreparedDownloadsControllerTests : IClassFixture<PreparedDownloadsResultsFake>,
+                                                IClassFixture<UserClaimsPrincipalFake>
 {
-    [Trait("PreparedDownloads", "PreparedDownloads Controller Unit Tests")]
-    public class PrePreparedDownloadsControllerTests : IClassFixture<PreparedDownloadsResultsFake>,
-                                                    IClassFixture<UserClaimsPrincipalFake>
+    private readonly PreparedDownloadsResultsFake _preparedDownloadsResultsFake;
+    private readonly UserClaimsPrincipalFake _userClaimsPrincipalFake;
+    private readonly IPrePreparedDownloadsService _mockprePreparedDownloadsService = Substitute.For<IPrePreparedDownloadsService>();
+    private readonly ISession _mockSession = Substitute.For<ISession>();
+    private readonly IOptions<AzureAppSettings> _mockAzureAppSettings = Substitute.For<IOptions<AzureAppSettings>>();
+
+    public PrePreparedDownloadsControllerTests(PreparedDownloadsResultsFake preparedDownloadsResultsFake,
+                                            UserClaimsPrincipalFake userClaimsPrincipalFake)
     {
-        private readonly PreparedDownloadsResultsFake _preparedDownloadsResultsFake;
-        private readonly UserClaimsPrincipalFake _userClaimsPrincipalFake;
-        private readonly IPrePreparedDownloadsService _mockprePreparedDownloadsService = Substitute.For<IPrePreparedDownloadsService>();
-        private readonly ISession _mockSession = Substitute.For<ISession>();
-        private readonly IOptions<AzureAppSettings> _mockAzureAppSettings = Substitute.For<IOptions<AzureAppSettings>>();
+        _preparedDownloadsResultsFake = preparedDownloadsResultsFake;
+        _userClaimsPrincipalFake = userClaimsPrincipalFake;
+    }
 
-        public PrePreparedDownloadsControllerTests(PreparedDownloadsResultsFake preparedDownloadsResultsFake,
-                                                UserClaimsPrincipalFake userClaimsPrincipalFake)
+    [Fact]
+    public async Task PreparedDownloadsController_Should_Returns_Correct_View()
+    {
+        // Arrange
+        Mock<IPrePreparedDownloadsService> mockPrePreparedDownloads = new();
+
+        mockPrePreparedDownloads.Setup((repo) =>
+            repo.GetPrePreparedDownloadsList(
+                It.IsAny<AzureFunctionHeaderDetails>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .ReturnsAsync(_preparedDownloadsResultsFake.GetPrePreparedDownloadsList());
+
+        _mockAzureAppSettings.Value.Returns(new AzureAppSettings
         {
-            _preparedDownloadsResultsFake = preparedDownloadsResultsFake;
-            _userClaimsPrincipalFake = userClaimsPrincipalFake;
-        }
-        [Fact]
-        public async Task PreparedDownloadsController_Should_Returns_Correct_View()
+            IsSessionIdStoredInCookie = true
+        });
+
+        PreparedDownloadsController controller = GetPreparedDownloadsController(mockPrePreparedDownloads);
+
+        // Act
+        IActionResult result = await controller.GetPreparedDownloadsAsync();
+
+        // Assert
+        ViewResult viewResult = Assert.IsType<ViewResult>(result, exactMatch: false);
+        Assert.NotNull(viewResult);
+
+        PrePreparedDownloadsViewModel? viewModel = viewResult.Model as PrePreparedDownloadsViewModel;
+        Assert.NotNull(viewModel);
+
+        Assert.Equal("~/Views/PrePreparedDownloads/PrePreparedDownload.cshtml", viewResult.ViewName);
+    }
+
+    [Fact]
+    public async Task PreparedDownloadsController_Should_Returns_List_With_PrePrepareddownloads()
+    {
+        // Arrange
+        List<Domain.Models.PrePreparedDownloads.PrePreparedDownloads> results = _preparedDownloadsResultsFake.GetPrePreparedDownloadsList();
+        Mock<IPrePreparedDownloadsService> mockPrePreparedDownloads = new();
+        mockPrePreparedDownloads.Setup(repo => repo.GetPrePreparedDownloadsList(It.IsAny<AzureFunctionHeaderDetails>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(_preparedDownloadsResultsFake.GetPrePreparedDownloadsList());
+        _mockAzureAppSettings.Value.Returns(new AzureAppSettings
         {
-            // Arrange
-            var results = _preparedDownloadsResultsFake.GetPrePreparedDownloadsList();
-            var mockPrePreparedDownloads = new Mock<IPrePreparedDownloadsService>();
-            mockPrePreparedDownloads.Setup(repo => repo.GetPrePreparedDownloadsList(It.IsAny<AzureFunctionHeaderDetails>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(_preparedDownloadsResultsFake.GetPrePreparedDownloadsList());
-            _mockAzureAppSettings.Value.Returns(new AzureAppSettings
-            {
-                IsSessionIdStoredInCookie = true
-            });
-            var model = _preparedDownloadsResultsFake.GetGetPrePreparedDownloadsDetails();
-            var controller = GetPreparedDownloadsController(mockPrePreparedDownloads);
+            IsSessionIdStoredInCookie = true
+        });
+        PreparedDownloadsController controller = GetPreparedDownloadsController(mockPrePreparedDownloads);
 
-            // Act
-            var result = await controller.GetPreparedDownloadsAsync().ConfigureAwait(false);
+        // Act
+        IActionResult result = await controller.GetPreparedDownloadsAsync();
 
-            // Assert
-            var viewResult = Assert.IsAssignableFrom<ViewResult>(result);
-            var viewModel = viewResult.Model as PrePreparedDownloadsViewModel;
+        // Assert
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
+        Assert.NotNull(viewResult);
 
-            viewResult.ViewName.Should().Be("~/Views/PrePreparedDownloads/PrePreparedDownload.cshtml");
+        PrePreparedDownloadsViewModel? viewModel = viewResult.Model as PrePreparedDownloadsViewModel;
+        Assert.NotNull(viewModel);
 
-
-        }
-        [Fact]
-        public async Task PreparedDownloadsController_Should_Returns_List_With_PrePrepareddownloads()
-        {
-            // Arrange
-            var results = _preparedDownloadsResultsFake.GetPrePreparedDownloadsList();
-            var mockPrePreparedDownloads = new Mock<IPrePreparedDownloadsService>();
-            mockPrePreparedDownloads.Setup(repo => repo.GetPrePreparedDownloadsList(It.IsAny<AzureFunctionHeaderDetails>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(_preparedDownloadsResultsFake.GetPrePreparedDownloadsList());
-            _mockAzureAppSettings.Value.Returns(new AzureAppSettings
-            {
-                IsSessionIdStoredInCookie = true
-            });
-            var model = _preparedDownloadsResultsFake.GetGetPrePreparedDownloadsDetails();
-            var controller = GetPreparedDownloadsController(mockPrePreparedDownloads);
-
-            // Act
-            var result = await controller.GetPreparedDownloadsAsync().ConfigureAwait(false);
-
-            // Assert
-            var viewResult = Assert.IsAssignableFrom<ViewResult>(result);
-            var viewModel = viewResult.Model as PrePreparedDownloadsViewModel;
-
-            viewModel.PrePreparedDownloadList.Count.Should().Be(results.Count);
-
-        }
-        [Fact]
-        public async Task GetPreparedDownloadsController_DownloadPrePreparedFile_Should_Return_File()
-        {
-            // Arrange
-            var model = _preparedDownloadsResultsFake.GetMetaDataFile();
-            var mockPrePreparedDownloads = new Mock<IPrePreparedDownloadsService>();
-            mockPrePreparedDownloads.Setup(repo => repo.GetPrePreparedDownloadsList(It.IsAny<AzureFunctionHeaderDetails>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(_preparedDownloadsResultsFake.GetPrePreparedDownloadsList());
-            _mockAzureAppSettings.Value.Returns(new AzureAppSettings
-            {
-                IsSessionIdStoredInCookie = true
-            });
-            var azureFunctionHeaderDetails = new AzureFunctionHeaderDetails() { ClientId = "123456", SessionId = "654321" };
-            var ms = new MemoryStream();
-            _mockprePreparedDownloadsService.PrePreparedDownloadsFileAsync("", ms, azureFunctionHeaderDetails).Returns(Task.FromResult(model));
-            _mockAzureAppSettings.Value.Returns(new AzureAppSettings { IsSessionIdStoredInCookie = false });
-            var controller = GetPreparedDownloadsController(mockPrePreparedDownloads);
-
-            // Act
-            var result = await controller.DownloadPrePreparedFile("PrePreparedDownloadTestFile.csv", DateTime.Now).ConfigureAwait(false);
-
-            // Assert
-            Assert.Equal(result.FileDownloadName, model.FileDownloadName);
-            Assert.Equal(result.ContentType, model.ContentType);
-        }
-        private PreparedDownloadsController GetPreparedDownloadsController(Mock<IPrePreparedDownloadsService> mockPrePreparedDownloadsService)
-        {
-            var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-
-            var _commonService = new Mock<ICommonService>();
-
-            var _mockCookieManager = new Mock<ICookieManager>();
-
-
-            return new PreparedDownloadsController(_commonService.Object, mockPrePreparedDownloadsService.Object)
-            {
-                ControllerContext = new ControllerContext()
-                {
-                    HttpContext = new DefaultHttpContext { User = user, Session = _mockSession },
-                }
-            };
-        }
+        Assert.Equal(results.Count, viewModel.PrePreparedDownloadList.Count);
 
     }
+    [Fact]
+    public async Task GetPreparedDownloadsController_DownloadPrePreparedFile_Should_Return_File()
+    {
+        // Arrange
+        FileStreamResult model = _preparedDownloadsResultsFake.GetMetaDataFile();
+        Mock<IPrePreparedDownloadsService> mockPrePreparedDownloads = new();
+        mockPrePreparedDownloads.Setup((repo) =>
+            repo.GetPrePreparedDownloadsList(
+                It.IsAny<AzureFunctionHeaderDetails>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .ReturnsAsync(_preparedDownloadsResultsFake.GetPrePreparedDownloadsList());
+
+        _mockAzureAppSettings.Value.Returns(new AzureAppSettings
+        {
+            IsSessionIdStoredInCookie = true
+        });
+        AzureFunctionHeaderDetails azureFunctionHeaderDetails = new () { ClientId = "123456", SessionId = "654321" };
+        MemoryStream ms = new();
+        _mockprePreparedDownloadsService.PrePreparedDownloadsFileAsync("", ms, azureFunctionHeaderDetails).Returns(Task.FromResult(model));
+        _mockAzureAppSettings.Value.Returns(new AzureAppSettings { IsSessionIdStoredInCookie = false });
+        PreparedDownloadsController controller = GetPreparedDownloadsController(mockPrePreparedDownloads);
+
+        // Act
+        FileStreamResult result = await controller.DownloadPrePreparedFile("PrePreparedDownloadTestFile.csv", DateTime.Now);
+
+        // Assert
+        Assert.Equal(result.FileDownloadName, model.FileDownloadName);
+        Assert.Equal(result.ContentType, model.ContentType);
+    }
+
+    private PreparedDownloadsController GetPreparedDownloadsController(Mock<IPrePreparedDownloadsService> mockPrePreparedDownloadsService)
+    {
+        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+
+        Mock<ICommonService> _commonService = new();
+
+        return new PreparedDownloadsController(_commonService.Object, mockPrePreparedDownloadsService.Object)
+        {
+            ControllerContext = new ControllerContext()
+            {
+                HttpContext = new DefaultHttpContext { User = user, Session = _mockSession },
+            }
+        };
+    }
+
 }

--- a/DfE.GIAP.All/DfE.GIAP.Web.Tests/DfE.GIAP.Web.Tests.csproj
+++ b/DfE.GIAP.All/DfE.GIAP.Web.Tests/DfE.GIAP.Web.Tests.csproj
@@ -5,7 +5,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
## 📌 Summary

Given FluentAssertions V8 has gone commercial with licensing. Removal or pinning to 7.x appears to be the correct approach for a library that is easily replaceable. 

Our usage is light, 2 classes use it in 2 csprojs. From #84 this was noticed as a bump request.

So this PR removes `FluentAssertions` and replaces with standard asserts.

## 🧪 Changes Made

- [x] Refactoring:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
