### PR TITLE
extend optionstestdoubles to handle configuring values, fulfil consen…

### DIFF
--- a/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/Contents/Tests/Options/PageContentOptionsProviderTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/Contents/Tests/Options/PageContentOptionsProviderTests.cs
@@ -16,7 +16,7 @@ public sealed class PageContentOptionsProviderTests
     [Fact]
     public void PageOptionsContentProvider_Constructor_ThrowsNullException_When_CreatedWithNullOptionsValue()
     {
-        IOptions<PageContentOptions> nullValueOptions = OptionsTestDoubles.WithNullValue<PageContentOptions>();
+        IOptions<PageContentOptions> nullValueOptions = OptionsTestDoubles.ConfigureOptionsWithNullValue<PageContentOptions>();
         Action construct = () => new PageContentOptionProvider(nullValueOptions);
         Assert.Throws<ArgumentNullException>(construct);
     }

--- a/DfE.GIAP.All/DfE.GIAP.SharedTests/TestDoubles/OptionsTestDoubles.cs
+++ b/DfE.GIAP.All/DfE.GIAP.SharedTests/TestDoubles/OptionsTestDoubles.cs
@@ -6,15 +6,31 @@ public static class OptionsTestDoubles
 {
     public static IOptions<T> Default<T>() where T : class, new()
     {
-        return WithValue(new T());
+        return ConfigureOptions(new T());
     }
 
-    public static IOptions<T> WithNullValue<T>() where T : class
+    public static IOptions<T> ConfigureOptionsWithNullValue<T>() where T : class
     {
-        return WithValue<T>(null);
+        return ConfigureOptions<T>(value: null);
     }
 
-    public static IOptions<T> WithValue<T>(T? value) where T : class
+    public static IOptions<T> ConfigureOptions<T>(Action<T> configure) where T : class, new()
+    {
+        Mock<IOptions<T>> mock = new();
+
+        mock.Setup((t) => t.Value)
+            .Returns(() =>
+            {
+                T configurable = new();
+                configure(configurable);
+                return configurable;
+            })
+            .Verifiable();
+
+        return mock.Object;
+    }
+
+    private static IOptions<T> ConfigureOptions<T>(T? value) where T : class
     {
         Mock<IOptions<T>> mock = new();
         mock.Setup(t => t.Value).Returns(value!).Verifiable();

--- a/DfE.GIAP.All/DfE.GIAP.Web.Tests/TestDoubles/ConsentResultsFake.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Web.Tests/TestDoubles/ConsentResultsFake.cs
@@ -1,16 +1,19 @@
-﻿using DfE.GIAP.Core.Models.Common;
+﻿using DfE.GIAP.Core.Contents.Application.Models;
 using DfE.GIAP.Web.ViewModels;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace DfE.GIAP.Web.Tests.TestDoubles
+namespace DfE.GIAP.Web.Tests.TestDoubles;
+
+public class ConsentResultsFake
 {
-    public class ConsentResultsFake
+    public ConsentViewModel GetConsent()
     {
-        public ConsentViewModel GetConsent()
+        return new ConsentViewModel()
         {
-            return new ConsentViewModel() { Response = new CommonResponseBody() { Title = "test Title", Body = "test Body" } };
-        }
+            Response = new Content()
+            {
+                Title = "test Title",
+                Body = "test Body"
+            }
+        };
     }
 }

--- a/DfE.GIAP.All/DfE.GIAP.Web.Tests/TestDoubles/TestSession.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Web.Tests/TestDoubles/TestSession.cs
@@ -1,81 +1,49 @@
-﻿using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using DfE.GIAP.Common.Constants.AzureFunction;
+using Microsoft.AspNetCore.Http;
 
-namespace DfE.GIAP.Web.Tests.TestDoubles
+namespace DfE.GIAP.Web.Tests.TestDoubles;
+
+public class TestSession : ISession
 {
-    public class TestSession : ISession
+
+    public TestSession()
     {
+        Values = [];
+    }
 
-        public TestSession()
+    public string Id => HeaderDetails.SessionId;
+
+    public bool IsAvailable => true;
+
+    public IEnumerable<string> Keys => Values.Keys;
+
+    public Dictionary<string, byte[]> Values { get; set; }
+
+    public void Clear() => Values.Clear();
+
+    public Task CommitAsync(CancellationToken token) => throw new NotImplementedException();
+
+    public Task LoadAsync(CancellationToken token) => throw new NotImplementedException();
+
+    public void Remove(string key) => Values.Remove(key);
+
+    public void Set(string key, byte[] value)
+    {
+        if (Values.ContainsKey(key))
         {
-            Values = new Dictionary<string, byte[]>();
+            Remove(key);
         }
+        Values.Add(key, value);
+    }
 
-        public string Id
+    public bool TryGetValue(string key, out byte[] value)
+    {
+        if (Values.TryGetValue(key, out byte[]? output))
         {
-            get
-            {
-                return "session_id";
-            }
+            value = output;
+            return true;
         }
-
-        public bool IsAvailable
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        public IEnumerable<string> Keys
-        {
-            get { return Values.Keys; }
-        }
-
-        public Dictionary<string, byte[]> Values { get; set; }
-
-        public void Clear()
-        {
-            Values.Clear();
-        }
-
-        public Task CommitAsync(CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task LoadAsync(CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Remove(string key)
-        {
-            Values.Remove(key);
-        }
-
-        public void Set(string key, byte[] value)
-        {
-            if (Values.ContainsKey(key))
-            {
-                Remove(key);
-            }
-            Values.Add(key, value);
-        }
-
-        public bool TryGetValue(string key, out byte[] value)
-        {
-            if (Values.ContainsKey(key))
-            {
-                value = Values[key];
-                return true;
-            }
-            value = new byte[0];
-            return false;
-        }
+        value = [];
+        return false;
     }
 }

--- a/DfE.GIAP.All/DfE.GIAP.Web/Helpers/Consent/ConsentHelper.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Web/Helpers/Consent/ConsentHelper.cs
@@ -1,27 +1,15 @@
-﻿using Microsoft.AspNetCore.Http;
-using System;
-using System.Linq;
+﻿namespace DfE.GIAP.Web.Helpers.Consent;
 
-namespace DfE.GIAP.Web.Helpers.Consent
+public static class ConsentHelper
 {
-    public static class ConsentHelper
-    {
-        public const string ConsentKey = "cg";
-        public const string ConsentValue = "yes";
+    public const string ConsentKey = "cg";
+    public const string ConsentValue = "yes";
 
-        public static bool HasGivenConsent(HttpContext context)
-        {
-            return context.Session.Keys.Contains(ConsentKey) && context.Session.GetString(ConsentKey).Equals(ConsentValue);
-        }
+    public static bool HasGivenConsent(HttpContext context)
+        => context.Session.Keys.Contains(ConsentKey) &&
+            context.Session.GetString(ConsentKey).Equals(ConsentValue);
 
-        public static void SetConsent(HttpContext context)
-        {
-            context.Session.SetString(ConsentKey, ConsentValue);
-        }
+    public static void SetConsent(HttpContext context) => context.Session.SetString(ConsentKey, ConsentValue);
 
-        public static void RemoveConsent(HttpContext context)
-        {
-            context.Session.Remove(ConsentKey);
-        }
-    }
+    public static void RemoveConsent(HttpContext context) => context.Session.Remove(ConsentKey);
 }

--- a/DfE.GIAP.All/DfE.GIAP.Web/ViewModels/ConsentViewModel.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Web/ViewModels/ConsentViewModel.cs
@@ -1,15 +1,12 @@
-﻿using DfE.GIAP.Core.Models.Common;
+﻿using DfE.GIAP.Core.Contents.Application.Models;
 using System.Diagnostics.CodeAnalysis;
 
-namespace DfE.GIAP.Web.ViewModels
+namespace DfE.GIAP.Web.ViewModels;
+
+[ExcludeFromCodeCoverage]
+public class ConsentViewModel
 {
-    [ExcludeFromCodeCoverage]
-    public class ConsentViewModel
-    {
-        public CommonResponseBody Response { get; set; }
-
-        public bool ConsentGiven { get; set; }
-
-        public bool ConsentError { get; set; }
-    }
+    public Content Response { get; set; }
+    public bool ConsentGiven { get; set; }
+    public bool ConsentError { get; set; }
 }

--- a/DfE.GIAP.All/DfE.GIAP.Web/appsettings.json
+++ b/DfE.GIAP.All/DfE.GIAP.Web/appsettings.json
@@ -75,7 +75,10 @@
       "DocumentId": "Accessibility"
     },
     "AccessibilityReport": {
-      "DocumentId": "AccessibilityReport"
+        "DocumentId": "AccessibilityReport"
+    },
+    "Consent": {
+        "DocumentId":  "Consent"
     }
   }
 }


### PR DESCRIPTION

## 📌 Summary

Use `GetContentByPageKeyUseCase` for `ConsentController`.
Add tests over `ConsentController`.
Extend `OptionsTestDoubles` to pass a lambda to configure.

## 🔍 Related Issue(s)

#69 

## 🧪 Changes Made

- [x] Refactoring
## 📝 Description

## 📸 Screenshots (if applicable)

Without selecting consent; errors
![image](https://github.com/user-attachments/assets/53bb6025-ec3c-4397-9d4f-14ec8ff43cfa)

Giving consent;
![image](https://github.com/user-attachments/assets/26e1b207-b5fb-48ab-8ddd-c07f78507c89)
![image](https://github.com/user-attachments/assets/9ea1831f-9902-47a6-8183-ad5c3fda0dbd)


## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
