### PR TITLE
remove pragma warningsCA1861  and wrap construction unit tests with Func

### DIFF
--- a/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/Contents/Tests/Infrastructure/CosmosDbContentReadOnlyRepositoryTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/Contents/Tests/Infrastructure/CosmosDbContentReadOnlyRepositoryTests.cs
@@ -23,8 +23,7 @@ public sealed class CosmosDbContentReadOnlyRepositoryTests
     public void CosmosDbContentReadOnlyRepository_Constructor_ThrowsNullException_When_CreatedWithNull_Logger()
     {
         // Arrange
-#pragma warning disable CA1806 // Do not ignore method results
-        Action construct = () => new CosmosDbContentReadOnlyRepository(
+        Func<CosmosDbContentReadOnlyRepository> construct = () => new CosmosDbContentReadOnlyRepository(
             logger: null!,
             contentDtoToContentMapper: _mockMapper.Object,
             cosmosDbQueryHandler: _mockCosmosDbQueryHandler.Object);
@@ -37,7 +36,7 @@ public sealed class CosmosDbContentReadOnlyRepositoryTests
     public void CosmosDbContentReadOnlyRepository_Constructor_ThrowsNullException_When_CreatedWithNull_Mapper()
     {
         // Arrange
-        Action construct = () => new CosmosDbContentReadOnlyRepository(
+        Func<CosmosDbContentReadOnlyRepository> construct = () => new CosmosDbContentReadOnlyRepository(
             logger: _mockLogger,
             contentDtoToContentMapper: null!,
             cosmosDbQueryHandler: _mockCosmosDbQueryHandler.Object);
@@ -50,7 +49,7 @@ public sealed class CosmosDbContentReadOnlyRepositoryTests
     public void CosmosDbContentReadOnlyRepository_Constructor_ThrowsNullException_When_CreatedWithNull_CosmosQueryHandler()
     {
         // Arrange
-        Action construct = () => new CosmosDbContentReadOnlyRepository(
+        Func<CosmosDbContentReadOnlyRepository> construct = () => new CosmosDbContentReadOnlyRepository(
             logger: _mockLogger,
             contentDtoToContentMapper: _mockMapper.Object,
             cosmosDbQueryHandler: null!);
@@ -58,7 +57,6 @@ public sealed class CosmosDbContentReadOnlyRepositoryTests
         // Act Assert
         Assert.Throws<ArgumentNullException>(construct);
     }
-#pragma warning restore CA1806 // Do not ignore method results
 
     [Fact]
     public async Task CosmosDbContentReadOnlyRepository_GetContentByIdAsync_Throws_When_NonCosmosExceptionOccurs()

--- a/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/CreateNewsArticle/CreateNewsArticleUseCaseTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/CreateNewsArticle/CreateNewsArticleUseCaseTests.cs
@@ -7,9 +7,7 @@ public sealed class CreateNewsArticleUseCaseTests
     public void Constructor_ThrowsNullException_When_CreatedWithNullRepository()
     {
         // Arrange
-#pragma warning disable CA1806 // Do not ignore method results
-        Action construct = () => new CreateNewsArticleUseCase(newsArticleWriteRepository: null!);
-#pragma warning restore CA1806 // Do not ignore method results
+        Func<CreateNewsArticleUseCase> construct = () => new CreateNewsArticleUseCase(newsArticleWriteRepository: null!);
 
         // Act Assert
         Assert.Throws<ArgumentNullException>(construct);

--- a/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/GetNewsArticles/GetNewsArticlesUseCaseTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/GetNewsArticles/GetNewsArticlesUseCaseTests.cs
@@ -9,9 +9,7 @@ public sealed class GetNewsArticlesUseCaseTests
     public void Constructor_ThrowsNullException_When_CreatedWithNullRepository()
     {
         // Arrange
-#pragma warning disable CA1806 // Do not ignore method results
-        Action construct = () => new GetNewsArticlesUseCase(newsArticleReadRepository: null!);
-#pragma warning restore CA1806 // Do not ignore method results
+        Func<GetNewsArticlesUseCase> construct = () => new GetNewsArticlesUseCase(newsArticleReadRepository: null!);
 
         // Act Assert
         Assert.Throws<ArgumentNullException>(construct);

--- a/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/GetNewsArticlesById/GetNewsArticleByIdUseCaseTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/GetNewsArticlesById/GetNewsArticleByIdUseCaseTests.cs
@@ -7,9 +7,10 @@ public sealed class GetNewsArticleByIdUseCaseTests
     [Fact]
     public void Constructor_ThrowsNullException_When_CreatedWithNullRepository()
     {
-#pragma warning disable CA1806 // Do not ignore method results
-        Action construct = () => new GetNewsArticleByIdUseCase(newsArticleReadRepository: null!);
-#pragma warning restore CA1806 // Do not ignore method results
+        // Arrange
+        Func<GetNewsArticleByIdUseCase> construct = () => new GetNewsArticleByIdUseCase(newsArticleReadRepository: null!);
+
+        // Act
         Assert.Throws<ArgumentNullException>(construct);
     }
 

--- a/DfE.GIAP.All/DfE.GIAP.Web.Tests/Accessibility/AccessibilityControllerTests.cs
+++ b/DfE.GIAP.All/DfE.GIAP.Web.Tests/Accessibility/AccessibilityControllerTests.cs
@@ -15,7 +15,6 @@ namespace DfE.GIAP.Web.Tests.Accessibility;
 [Trait("Category", "Accessibility Controller Unit Tests")]
 public sealed class AccessibilityControllerTests
 {
-#pragma warning disable CA1806 // Do not ignore method results
 
     [Fact]
     public void AccessibilityController_Throws_When_ConstructedWithNullArgs_UseCase()
@@ -25,7 +24,7 @@ public sealed class AccessibilityControllerTests
             MapperTestDoubles.Default<GetContentByPageKeyUseCaseResponse, AccessibilityViewModel>();
 
         // Act
-        Action construct = () => new AccessibilityController(null!, mockMapper.Object);
+        Func<AccessibilityController> construct = () => new AccessibilityController(null!, mockMapper.Object);
 
         // Assert
         Assert.Throws<ArgumentNullException>(construct);
@@ -34,15 +33,13 @@ public sealed class AccessibilityControllerTests
     [Fact]
     public void AccessibilityController_Throws_When_ConstructedWithNullArgs_Mapper()
     {
-        // Arrange Act
+        // Arrange
         Mock<IUseCase<GetContentByPageKeyUseCaseRequest, GetContentByPageKeyUseCaseResponse>> _mockUseCase = new();
-        Action construct = () => new AccessibilityController(_mockUseCase.Object, null!);
+        Func<AccessibilityController> construct = () => new AccessibilityController(_mockUseCase.Object, null!);
 
-        // Assert
+        // Act Assert
         Assert.Throws<ArgumentNullException>(construct);
     }
-
-#pragma warning restore CA1806
 
     [Fact]
     public async Task AccessibilityController_Index_Throws_When_ResponseContentIsNull()


### PR DESCRIPTION
## 📌 Summary

Avoids disabling the pragma warnings by turning `Action` -> `Func<TReturn>`
## 🔍 Related Issue(s)

#63 

## 🧪 Changes Made

- [x] Refactoring

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
