### PR TITLE
UpdateNewsArticleUseCase RequestModel instead of NewsArticle

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/Models/NewsArticle.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/Models/NewsArticle.cs
@@ -14,9 +14,4 @@ public record NewsArticle
     public bool Published { get; set; }
     public bool Archived { get; set; }
     public bool Pinned { get; set; }
-
-    public void WithModifiedNow()
-    {
-        ModifiedDate = DateTime.UtcNow;
-    }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/CreateNewsArticle/CreateNewsArticleUseCase.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/CreateNewsArticle/CreateNewsArticleUseCase.cs
@@ -32,6 +32,7 @@ public class CreateNewsArticleUseCase : IUseCaseRequestOnly<CreateNewsArticleReq
         ArgumentException.ThrowIfNullOrWhiteSpace(request.Title);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.Body);
 
+        // TODO apply similar pattern UpdateNewsArticleRequestProperties
         NewsArticle newsArticle = new()
         {
             Id = NewsArticleIdentifier.New(),

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/UpdateNewsArticle/UpdateNewsArticleRequest.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/UpdateNewsArticle/UpdateNewsArticleRequest.cs
@@ -3,4 +3,24 @@ using DfE.GIAP.Core.NewsArticles.Application.Models;
 
 namespace DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
 
-public record UpdateNewsArticleRequest(NewsArticle NewsArticle) : IUseCaseRequest;
+public record UpdateNewsArticleRequest(UpdateNewsArticlesRequestProperties UpdateArticleProperties) : IUseCaseRequest;
+
+public record UpdateNewsArticlesRequestProperties
+{
+    public UpdateNewsArticlesRequestProperties(string id)
+    {
+        Id = NewsArticleIdentifier.From(id);
+        DateTime updateDate = DateTime.UtcNow;
+        ModifiedDate = updateDate;
+        CreatedDate = updateDate;
+    }
+
+    public NewsArticleIdentifier Id { get; }
+    public string? Title { get; init; }
+    public string? Body { get; init; }
+    public DateTime ModifiedDate { get; }
+    public DateTime CreatedDate { get; }
+    public bool? Archived { get; init; }
+    public bool? Pinned { get; init; }
+    public bool? Published { get; init; }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/CompositionRoot.cs
@@ -28,7 +28,8 @@ public static class CompositionRoot
     private static IServiceCollection RegisterApplicationDependencies(this IServiceCollection services)
     {
         return services
-            .RegisterApplicationUseCases();
+            .RegisterApplicationUseCases()
+            .AddSingleton<IMapper<UpdateNewsArticlesRequestProperties, NewsArticle>, UpdateNewsArticlesRequestPropertiesMapperToNewsArticle>();
     }
 
     private static IServiceCollection RegisterApplicationUseCases(this IServiceCollection services)

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/Admin/ManageDocuments/ManageDocumentsController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/Admin/ManageDocuments/ManageDocumentsController.cs
@@ -273,8 +273,7 @@ public class ManageDocumentsController : Controller
         GetNewsArticleByIdResponse response = await _getNewsArticleByIdUseCase.HandleRequestAsync(
             new GetNewsArticleByIdRequest(selectedNewsId));
 
-        if (response.NewsArticle is null)
-            ArgumentNullException.ThrowIfNull(response.NewsArticle);
+        ArgumentNullException.ThrowIfNull(response.NewsArticle);
 
         ManageDocumentsViewModel manageDocumentsModel = new()
         {
@@ -301,23 +300,22 @@ public class ManageDocumentsController : Controller
     {
         // TODO: Change to use specific view models, move away from "ManageDocumentsViewModel"
         if (!ModelState.IsValid)
-            return View("../Admin/ManageDocuments/EditNewsArticle", manageDocumentsModel);
-
-        // TODO: Porbably change to specific data for request, instead of NewsArticle
-        NewsArticle updatedArticle = new()
         {
-            Id = NewsArticleIdentifier.From(manageDocumentsModel.NewsArticle.Id),
+            return View("../Admin/ManageDocuments/EditNewsArticle", manageDocumentsModel);
+        }
+
+        // TODO sanitisation part of Application
+        UpdateNewsArticlesRequestProperties updateProperties = new(id: manageDocumentsModel.NewsArticle.Id)
+        {
             Title = SecurityHelper.SanitizeText(manageDocumentsModel.NewsArticle.Title),
             Body = SecurityHelper.SanitizeText(manageDocumentsModel.NewsArticle.Body),
+            Archived = manageDocumentsModel.NewsArticle.Archived,
             Pinned = manageDocumentsModel.NewsArticle.Pinned,
             Published = manageDocumentsModel.NewsArticle.Published,
-            Archived = manageDocumentsModel.NewsArticle.Archived,
-            CreatedDate = manageDocumentsModel.NewsArticle.CreatedDate,
-            ModifiedDate = manageDocumentsModel.NewsArticle.ModifiedDate
         };
 
         await _updateNewsArticleUseCase.HandleRequestAsync(
-            new UpdateNewsArticleRequest(updatedArticle));
+            new UpdateNewsArticleRequest(updateProperties));
 
         // Change to speciifc confirmation view model
         manageDocumentsModel.Confirmation = new()

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests.cs
@@ -1,0 +1,65 @@
+﻿using DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
+
+namespace DfE.GIAP.Core.UnitTests.NewsArticles.UseCases.UpdateNewsArticle;
+public sealed class UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests
+{
+    [Fact]
+    public void Mapper_Throws_When_Input_Is_Null()
+    {
+        // Arrange
+        UpdateNewsArticlesRequestPropertiesMapperToNewsArticle mapper = new();
+        Func<NewsArticle> act = () => mapper.Map(null!);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void Mapper_Maps_DefaultProperties_When_Input_Properties_Is_Null()
+    {
+        // Arrange
+        UpdateNewsArticlesRequestPropertiesMapperToNewsArticle mapper = new();
+        UpdateNewsArticlesRequestProperties properties = new(id: "VALID_ID");
+
+        // Act
+        NewsArticle result = mapper.Map(properties);
+
+        // Assert
+        Assert.Equal(properties.Id, result.Id);
+        Assert.Equal(string.Empty, result.Title);
+        Assert.Equal(string.Empty, result.Body);
+        Assert.Equal(properties.CreatedDate, result.CreatedDate);
+        Assert.Equal(properties.ModifiedDate, result.ModifiedDate);
+        Assert.False(result.Archived);
+        Assert.False(result.Pinned);
+        Assert.False(result.Published);
+    }
+
+    [Fact]
+    public void Mapper_Maps_Properties_When_Input_Properties_Have_Values()
+    {
+        // Arrange
+        UpdateNewsArticlesRequestPropertiesMapperToNewsArticle mapper = new();
+        UpdateNewsArticlesRequestProperties properties = new(id: "VALID_ID")
+        {
+            Archived = true,
+            Published = true,
+            Pinned = true,
+            Title = "Test tile",
+            Body = "Test body",
+        };
+
+        // Act
+        NewsArticle result = mapper.Map(properties);
+
+        // Assert
+        Assert.Equal(properties.Id, result.Id);
+        Assert.Equal(properties.Title, result.Title);
+        Assert.Equal(properties.Body, result.Body);
+        Assert.Equal(properties.CreatedDate, result.CreatedDate);
+        Assert.Equal(properties.ModifiedDate, result.ModifiedDate);
+        Assert.Equal(properties.Archived, result.Archived);
+        Assert.Equal(properties.Pinned, result.Pinned);
+        Assert.Equal(properties.Published, result.Published);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleUseCaseTests.cs
@@ -76,7 +76,7 @@ public sealed class UpdateNewsArticleUseCaseTests
     {
         // Arrange
         NewsArticle stub = NewsArticleTestDoubles.Create();
-        Mock<IMapper<UpdateNewsArticlesRequestProperties, NewsArticle>> mockMapper = MapperTestDoubles.MockFor< UpdateNewsArticlesRequestProperties, NewsArticle>(() => stub);
+        Mock<IMapper<UpdateNewsArticlesRequestProperties, NewsArticle>> mockMapper = MapperTestDoubles.MockFor<UpdateNewsArticlesRequestProperties, NewsArticle>(() => stub);
         Mock<INewsArticleWriteRepository> mockRepository = NewsArticleWriteOnlyRepositoryTestDoubles.Default();
         UpdateNewsArticleUseCase sut = new(mockRepository.Object, mockMapper.Object);
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleUseCaseTests.cs
@@ -1,4 +1,5 @@
-﻿using DfE.GIAP.Core.Common.CrossCutting;
+﻿using System.Diagnostics;
+using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
 using DfE.GIAP.Core.SharedTests.TestDoubles;
 
@@ -13,8 +14,31 @@ public sealed class UpdateNewsArticleUseCaseTests
     [InlineData("\r\n ")]
     public void UpdateNewsArticleRequestProperties_Throws_When_Identifier_Is_NullOrWhitespace(string? id)
     {
-        Action construct = () => new UpdateNewsArticlesRequestProperties(id!);
+        Func<UpdateNewsArticlesRequestProperties> construct = () => new UpdateNewsArticlesRequestProperties(id!);
         Assert.ThrowsAny<ArgumentException>(construct);
+    }
+
+    [Fact]
+    public void UpdateNewsArticleRequestProperties_Default_Properties_When_Constructed()
+    {
+        // Arrange
+        DateTime utcDateBeforeCreation = DateTime.UtcNow;
+        Stopwatch watch = Stopwatch.StartNew();
+
+        // Act
+        UpdateNewsArticlesRequestProperties properties = new(id: "VALID_ID");
+        watch.Stop();
+
+        // Assert
+        Assert.Equal("VALID_ID", properties.Id.Value);
+        Assert.InRange(properties.CreatedDate, utcDateBeforeCreation, utcDateBeforeCreation.Add(watch.Elapsed));
+        Assert.InRange(properties.ModifiedDate, utcDateBeforeCreation, utcDateBeforeCreation.Add(watch.Elapsed));
+
+        Assert.Null(properties.Title);
+        Assert.Null(properties.Body);
+        Assert.Null(properties.Archived);
+        Assert.Null(properties.Pinned);
+        Assert.Null(properties.Published);
     }
 
     [Fact]


### PR DESCRIPTION
## 📌 Summary

As per #105.
`UpdateNewsArticle`

UpdateNewsArticleRequest object rather than creating the NewsArticle which should become a read model over time?

## 🧪 Changes Made

- [x] Refactoring

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
