### PR TITLE
BaseIntegrationTest for common setup/teardown

### DIFF
--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/BaseIntegrationTest.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/BaseIntegrationTest.cs
@@ -1,0 +1,50 @@
+﻿namespace DfE.GIAP.Core.IntegrationTests;
+public abstract class BaseIntegrationTest : IAsyncLifetime
+{
+    private readonly IServiceCollection _services;
+    private IServiceScope? _testServicesScope;
+    protected CosmosDbFixture Fixture { get; }
+
+    protected BaseIntegrationTest(CosmosDbFixture fixture)
+    {
+        _services = ServiceCollectionTestDoubles.Default();
+        Fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await SetupAsync();
+        await OnInitializeAsync(_services);
+        EnsureServicesScope();
+    }
+
+    protected virtual Task OnInitializeAsync(IServiceCollection services) => Task.CompletedTask;
+    protected virtual Task OnDisposeAsync() => Task.CompletedTask;
+    protected T ResolveTypeFromScopedContext<T>() where T : notnull
+    {
+        EnsureServicesScope();
+        return _testServicesScope!.ServiceProvider.GetRequiredService<T>();
+    }
+
+    private void EnsureServicesScope()
+    {
+        ArgumentNullException.ThrowIfNull(_services);
+        if(_testServicesScope == null)
+        {
+            ServiceProvider provider = _services.BuildServiceProvider();
+            _testServicesScope = provider.CreateScope();
+        }
+    }
+
+    private async Task SetupAsync()
+    {
+        await Fixture.Database.ClearDatabaseAsync();
+        _services.AddSharedDependencies();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _testServicesScope?.Dispose();
+        await OnDisposeAsync();
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/BaseIntegrationTest.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/BaseIntegrationTest.cs
@@ -29,7 +29,7 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
     private void EnsureServicesScope()
     {
         ArgumentNullException.ThrowIfNull(_services);
-        if(_testServicesScope == null)
+        if (_testServicesScope == null)
         {
             ServiceProvider provider = _services.BuildServiceProvider();
             _testServicesScope = provider.CreateScope();

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/CreateNewsArticle/CreateNewsArticleUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/CreateNewsArticle/CreateNewsArticleUseCaseIntegrationTests.cs
@@ -3,17 +3,15 @@ using DfE.GIAP.Core.NewsArticles.Application.UseCases.CreateNewsArticle;
 
 namespace DfE.GIAP.Core.IntegrationTests.NewsArticles.CreateNewsArticle;
 [Collection(IntegrationTestCollectionMarker.Name)]
-public sealed class CreateNewsArticleUseCaseIntegrationTests : IAsyncLifetime
+public sealed class CreateNewsArticleUseCaseIntegrationTests : BaseIntegrationTest
 {
-    private readonly CosmosDbFixture _fixture;
+    public CreateNewsArticleUseCaseIntegrationTests(CosmosDbFixture fixture) : base(fixture) { }
 
-    public CreateNewsArticleUseCaseIntegrationTests(CosmosDbFixture fixture)
+    protected override Task OnInitializeAsync(IServiceCollection services)
     {
-        _fixture = fixture;
+        services.AddNewsArticleDependencies();
+        return Task.CompletedTask;
     }
-
-    public async Task InitializeAsync() => await _fixture.Database.ClearDatabaseAsync();
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Theory]
     [InlineData(true, true)]
@@ -21,16 +19,7 @@ public sealed class CreateNewsArticleUseCaseIntegrationTests : IAsyncLifetime
     public async Task CreateNewsArticles_Creates_Article(bool isPublished, bool isPinned)
     {
         // Arrange
-        IServiceCollection services =
-            ServiceCollectionTestDoubles.Default()
-                .AddSharedDependencies()
-                .AddNewsArticleDependencies();
-
-        IServiceProvider provider = services.BuildServiceProvider();
-        using IServiceScope scope = provider.CreateScope();
-
-        IUseCaseRequestOnly<CreateNewsArticleRequest> sut =
-            scope.ServiceProvider.GetService<IUseCaseRequestOnly<CreateNewsArticleRequest>>()!;
+        IUseCaseRequestOnly<CreateNewsArticleRequest> sut = ResolveTypeFromScopedContext<IUseCaseRequestOnly<CreateNewsArticleRequest>>()!;
 
         const string stubArticleTitle = "Test title";
         const string stubArticleBody = "Test body";
@@ -49,7 +38,7 @@ public sealed class CreateNewsArticleUseCaseIntegrationTests : IAsyncLifetime
         watch.Stop();
 
         // Assert
-        IEnumerable<NewsArticleDto> enumerable = await _fixture.Database.ReadManyAsync<NewsArticleDto>();
+        IEnumerable<NewsArticleDto> enumerable = await Fixture.Database.ReadManyAsync<NewsArticleDto>();
         NewsArticleDto newsArticleDto = Assert.Single(enumerable);
 
         Assert.False(string.IsNullOrEmpty(newsArticleDto.id));

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/DeleteNewsArticles/DeleteNewsArticlesUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/DeleteNewsArticles/DeleteNewsArticlesUseCaseIntegrationTests.cs
@@ -11,7 +11,7 @@ public sealed class DeleteNewsArticlesUseCaseIntegrationTests : BaseIntegrationT
         services.AddNewsArticleDependencies();
         return Task.CompletedTask;
     }
-    
+
     [Fact]
     public async Task DeleteNewsArticles_Deletes_SelectedArticle()
     {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/DeleteNewsArticles/DeleteNewsArticlesUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/DeleteNewsArticles/DeleteNewsArticlesUseCaseIntegrationTests.cs
@@ -1,40 +1,27 @@
-﻿using DfE.GIAP.Core.Common.CrossCutting;
-using DfE.GIAP.Core.NewsArticles.Application.UseCases.DeleteNewsArticle;
-using DfE.GIAP.Core.NewsArticles.Application.UseCases.GetNewsArticleById;
+﻿using DfE.GIAP.Core.NewsArticles.Application.UseCases.DeleteNewsArticle;
 
 namespace DfE.GIAP.Core.IntegrationTests.NewsArticles.DeleteNewsArticles;
 [Collection(IntegrationTestCollectionMarker.Name)]
-public sealed class DeleteNewsArticlesUseCaseIntegrationTests : IAsyncLifetime
+public sealed class DeleteNewsArticlesUseCaseIntegrationTests : BaseIntegrationTest
 {
-    private readonly CosmosDbFixture _fixture;
+    public DeleteNewsArticlesUseCaseIntegrationTests(CosmosDbFixture fixture) : base(fixture) { }
 
-    public DeleteNewsArticlesUseCaseIntegrationTests(CosmosDbFixture fixture)
+    protected override Task OnInitializeAsync(IServiceCollection services)
     {
-        _fixture = fixture;
+        services.AddNewsArticleDependencies();
+        return Task.CompletedTask;
     }
-
-    public async Task InitializeAsync() => await _fixture.Database.ClearDatabaseAsync();
-    public Task DisposeAsync() => Task.CompletedTask;
-
+    
     [Fact]
     public async Task DeleteNewsArticles_Deletes_SelectedArticle()
     {
         // Arrange
-        IServiceCollection services =
-            ServiceCollectionTestDoubles.Default()
-                .AddSharedDependencies()
-                .AddNewsArticleDependencies();
-
-        IServiceProvider provider = services.BuildServiceProvider();
-        using IServiceScope scope = provider.CreateScope();
-
-        IUseCaseRequestOnly<DeleteNewsArticleRequest> sut =
-            scope.ServiceProvider.GetService<IUseCaseRequestOnly<DeleteNewsArticleRequest>>()!;
+        IUseCaseRequestOnly<DeleteNewsArticleRequest> sut = ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeleteNewsArticleRequest>>()!;
 
         // Seed articles
         const int countGenerated = 10;
         List<NewsArticleDto> seededArticles = NewsArticleDtoTestDoubles.Generate(countGenerated);
-        await _fixture.Database.WriteManyAsync(seededArticles);
+        await Fixture.Database.WriteManyAsync(seededArticles);
 
         NewsArticleDto targetDeleteArticle = seededArticles[0];
         DeleteNewsArticleRequest request = new(Id: NewsArticleIdentifier.From(targetDeleteArticle.id));
@@ -44,7 +31,7 @@ public sealed class DeleteNewsArticlesUseCaseIntegrationTests : IAsyncLifetime
 
         //Assert
         IEnumerable<NewsArticleDto> newsArticleDtosShouldReturn = seededArticles.Where(t => t.id != targetDeleteArticle.id);
-        IEnumerable<NewsArticleDto?> queriedArticles = await _fixture.Database.ReadManyAsync<NewsArticleDto>(seededArticles.Select(t => t.id));
+        IEnumerable<NewsArticleDto?> queriedArticles = await Fixture.Database.ReadManyAsync<NewsArticleDto>(seededArticles.Select(t => t.id));
 
         Assert.Equivalent(newsArticleDtosShouldReturn, queriedArticles);
         Assert.Equal(countGenerated - 1, queriedArticles.Count(t => t != null));

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/ServiceCollectionTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/ServiceCollectionTestDoubles.cs
@@ -1,5 +1,4 @@
-﻿using DfE.GIAP.Core.NewsArticles;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
 namespace DfE.GIAP.Core.SharedTests.TestDoubles;
 public static class ServiceCollectionTestDoubles


### PR DESCRIPTION
## 📌 Summary

Some boilerplate happening in all test classes; Setting up a resolvable scope, IAsyncLifetime to clear the database. So push these all down into a base class, `OnInitializeAsync(IServiceCollection services)` to allow test to override for its specific features and register / run async actions before test starts.

## 🧪 Changes Made

- [x] Other (please describe): test improvement

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)