### PR TITLE
reuse getContentByPageKey for publicationSchedule and plannedMaintenance

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/NewsViewModel.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/NewsViewModel.cs
@@ -1,6 +1,6 @@
-﻿using DfE.GIAP.Core.Models.Common;
+﻿using System.Diagnostics.CodeAnalysis;
+using DfE.GIAP.Core.Contents.Application.Models;
 using DfE.GIAP.Core.NewsArticles.Application.Models;
-using System.Diagnostics.CodeAnalysis;
 
 namespace DfE.GIAP.Web.ViewModels;
 
@@ -8,6 +8,6 @@ namespace DfE.GIAP.Web.ViewModels;
 public class NewsViewModel
 {
     public IEnumerable<NewsArticle> NewsArticles { get; set; }
-    public CommonResponseBody NewsPublication { get; set; }
-    public CommonResponseBody NewsMaintenance { get; set; }
+    public Content NewsPublication { get; set; }
+    public Content NewsMaintenance { get; set; }
 }

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/News/NewsControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/News/NewsControllerTests.cs
@@ -1,15 +1,14 @@
-﻿using DfE.GIAP.Common.Enums;
-using DfE.GIAP.Core.Common.Application;
-using DfE.GIAP.Core.Models.Common;
+﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Contents.Application.Models;
+using DfE.GIAP.Core.Contents.Application.UseCases.GetContentByPageKeyUseCase;
 using DfE.GIAP.Core.NewsArticles.Application.Models;
 using DfE.GIAP.Core.NewsArticles.Application.UseCases.GetNewsArticles;
-using DfE.GIAP.Service.Content;
 using DfE.GIAP.Web.Controllers;
 using DfE.GIAP.Web.Helpers.Banner;
+using DfE.GIAP.Web.Tests.TestDoubles;
 using DfE.GIAP.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using NSubstitute;
 using Xunit;
 
 namespace DfE.GIAP.Web.Tests.Controllers.News;
@@ -17,50 +16,66 @@ namespace DfE.GIAP.Web.Tests.Controllers.News;
 [Trait("Category", "News Controller Unit Tests")]
 public class NewsControllerTests
 {
-    private readonly ILatestNewsBanner _mockNewsBanner = Substitute.For<ILatestNewsBanner>();
-    private readonly Mock<IUseCase<GetNewsArticlesRequest, GetNewsArticlesResponse>> _mockGetNewsArticlesUseCase = new();
 
     [Fact]
     public async Task IndexReturnsAViewWithPublicationData()
     {
         // Arrange
-        var listPublicationData = new CommonResponseBody() { Title = "Title 1", Body = "Test body 1", Date = new DateTime(2020, 1, 1) };
-        var listMaintenanceData = new CommonResponseBody() { Title = "Title 2", Body = "Test body 1", Date = new DateTime(2020, 1, 1) };
+        NewsArticle articleData1 = new()
+        {
+            Id = NewsArticleIdentifier.From("1"),
+            Title = "Title 1",
+            Body = "Test body 1",
+            DraftTitle = string.Empty,
+            DraftBody = string.Empty,
+            CreatedDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+        NewsArticle articleData2 = new()
+        {
+            Id = NewsArticleIdentifier.From("2"),
+            Title = "Title 2",
+            Body = "Test body 2",
+            DraftTitle = string.Empty,
+            DraftBody = string.Empty,
+            CreatedDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
 
-        var articleData1 = new NewsArticle() { Id = NewsArticleIdentifier.From("1"), Title = "Title 1", Body = "Test body 1", DraftTitle = string.Empty, DraftBody = string.Empty, CreatedDate = new DateTime(2020, 1, 1) };
-        var articleData2 = new NewsArticle() { Id = NewsArticleIdentifier.From("2"), Title = "Title 2", Body = "Test body 2", DraftTitle = string.Empty, DraftBody = string.Empty, CreatedDate = new DateTime(2020, 1, 1) };
-        var listArticleData = new List<NewsArticle>() { articleData1, articleData2 };
+        List<NewsArticle> listArticleData = [articleData1, articleData2];
 
-        var mockContentService = new Mock<IContentService>();
+        Content firstCallPublication = ContentTestDoubles.Default();
+        Content secondCallMaintenance = ContentTestDoubles.Default();
+        
+        Mock<IUseCase<GetNewsArticlesRequest, GetNewsArticlesResponse>> mockGetNewsArticlesUseCase = new();
+        Mock<IUseCase<GetContentByPageKeyUseCaseRequest, GetContentByPageKeyUseCaseResponse>> mockGetContentByPageKeyUseCase = new();
 
-        var newsViewModel = new NewsViewModel();
-        newsViewModel.NewsPublication = listPublicationData;
-        newsViewModel.NewsMaintenance = listMaintenanceData;
-        newsViewModel.NewsArticles = listArticleData;
 
-        mockContentService.Setup(repo => repo.GetContent(DocumentType.PublicationSchedule)).ReturnsAsync(listPublicationData);
-        mockContentService.Setup(repo => repo.GetContent(DocumentType.PlannedMaintenance)).ReturnsAsync(listMaintenanceData);
-        _mockGetNewsArticlesUseCase.Setup(repo => repo.HandleRequestAsync(It.IsAny<GetNewsArticlesRequest>()))
+        mockGetContentByPageKeyUseCase.SetupSequence(
+            (t) => t.HandleRequestAsync(
+                    It.IsAny<GetContentByPageKeyUseCaseRequest>()))
+                .ReturnsAsync(new GetContentByPageKeyUseCaseResponse(firstCallPublication))
+                .ReturnsAsync(new GetContentByPageKeyUseCaseResponse(secondCallMaintenance));
+
+        mockGetNewsArticlesUseCase.Setup(repo => repo.HandleRequestAsync(It.IsAny<GetNewsArticlesRequest>()))
             .ReturnsAsync(new GetNewsArticlesResponse(listArticleData));
 
-        var controller = new NewsController(mockContentService.Object, _mockNewsBanner, _mockGetNewsArticlesUseCase.Object);
+        ILatestNewsBanner _mockNewsBanner = new Mock<ILatestNewsBanner>().Object;
+
+        NewsController controller = new(_mockNewsBanner, mockGetNewsArticlesUseCase.Object, mockGetContentByPageKeyUseCase.Object);
 
         // Act
-        var result = await controller.Index().ConfigureAwait(false);
+        IActionResult result = await controller.Index();
 
         // Assert
-        mockContentService.Verify(x => x.GetContent(DocumentType.PublicationSchedule), Times.Once());
-        mockContentService.Verify(x => x.GetContent(DocumentType.PlannedMaintenance), Times.Once());
-        _mockGetNewsArticlesUseCase.Verify(x => x.HandleRequestAsync(It.IsAny<GetNewsArticlesRequest>()), Times.Once());
+        mockGetNewsArticlesUseCase.Verify(x => x.HandleRequestAsync(It.IsAny<GetNewsArticlesRequest>()), Times.Once());
+        mockGetContentByPageKeyUseCase.Verify(t => t.HandleRequestAsync(It.IsAny<GetContentByPageKeyUseCaseRequest>()), Times.Exactly(2));
 
-        var viewResult = Assert.IsType<ViewResult>(result);
-        var publicationModel = Assert.IsType<NewsViewModel>(
-            viewResult.ViewData.Model).NewsPublication;
-        Assert.Equal("Test body 1", publicationModel.Body);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
 
-        var maintenanceModel = Assert.IsType<NewsViewModel>(
-            viewResult.ViewData.Model).NewsMaintenance;
-        Assert.Equal("Test body 1", maintenanceModel.Body);
+        Content publicationModel = Assert.IsType<NewsViewModel>(viewResult.ViewData.Model).NewsPublication;
+        Assert.Equal(firstCallPublication.Body, publicationModel.Body);
+
+        Content maintenanceModel = Assert.IsType<NewsViewModel>(viewResult.ViewData.Model).NewsMaintenance;
+        Assert.Equal(secondCallMaintenance.Body, maintenanceModel.Body);
 
     }
 
@@ -69,15 +84,20 @@ public class NewsControllerTests
     public async Task DismissNewsBanner_redirects_to_ProvidedURL()
     {
         // Arrange
-        var mockContentService = new Mock<IContentService>();
+        Mock<ILatestNewsBanner> mockNewsBanner = new();
+        mockNewsBanner.Setup(t => t.RemoveLatestNewsStatus()).Verifiable();
 
-        var controller = new NewsController(mockContentService.Object, _mockNewsBanner, _mockGetNewsArticlesUseCase.Object);
+        Mock<IUseCase<GetNewsArticlesRequest, GetNewsArticlesResponse>> mockGetNewsArticlesUseCase = new();
+        Mock<IUseCase<GetContentByPageKeyUseCaseRequest, GetContentByPageKeyUseCaseResponse>> mockGetContentByPageKeyUseCase = new();
+
+        NewsController controller = new(mockNewsBanner.Object, mockGetNewsArticlesUseCase.Object, mockGetContentByPageKeyUseCase.Object);
 
         // Act
-        var result = await controller.DismissNewsBanner("testURL");
+        IActionResult result = await controller.DismissNewsBanner("testURL");
 
         // Assert
-        var viewResult = Assert.IsAssignableFrom<RedirectResult>(result);
-        Assert.True(viewResult.Url.Equals("testURL?returnToSearch=true"));
+        RedirectResult viewResult = Assert.IsType<RedirectResult>(result, exactMatch: false);
+        Assert.Equal("testURL?returnToSearch=true", viewResult.Url);
+        mockNewsBanner.Verify(t => t.RemoveLatestNewsStatus(), Times.Once);
     }
 }


### PR DESCRIPTION
## 📌 Summary

PlannedMaintenance and PublicationSchedule have already been implemented, they're used in `NewsController` too so just pull in and adjust tests.

## 🔍 Related Issue(s)

#69 

## 🧪 Changes Made

- [x] Refactoring

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
