### PR TITLE
sanitisation handler and sanitisation moved to application, inject ha…

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Handler/ITextSanitiserHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Handler/ITextSanitiserHandler.cs
@@ -1,0 +1,8 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+
+namespace DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+
+public interface ITextSanitiserHandler
+{
+    SanitisedTextResult Handle(string input);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Handler/SanitisedText.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Handler/SanitisedText.cs
@@ -1,0 +1,11 @@
+﻿namespace DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+
+public readonly struct SanitisedText
+{
+    public string Value { get; }
+
+    public SanitisedText(string? value)
+    {
+        Value = value ?? string.Empty;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Handler/TextSanitisationHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Handler/TextSanitisationHandler.cs
@@ -1,0 +1,32 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+
+namespace DfE.GIAP.Core.Common.Application.TextSanitiser.Handler;
+internal sealed class TextSanitiserHandler : ITextSanitiserHandler
+{
+    private readonly List<ITextSanitiser> _sanitisers;
+
+    public TextSanitiserHandler(IEnumerable<ITextSanitiser> sanitisers)
+    {
+        _sanitisers = [];
+        _sanitisers.AddRange(sanitisers ?? []);
+        _sanitisers.Add(new HtmlTextSanitiser()); // ensure this runs last in case the custom sanitisers are malicious or misconfigured
+    }
+
+    public SanitisedTextResult Handle(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return SanitisedTextResult.Empty();
+        }
+
+        string current = input;
+        foreach (ITextSanitiser sanitiser in _sanitisers)
+        {
+            SanitisedText result = sanitiser.Sanitise(current);
+            current = result.Value;
+        }
+
+        return SanitisedTextResult.From(current);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Sanitiser/HtmlTextSanitiser.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Sanitiser/HtmlTextSanitiser.cs
@@ -1,0 +1,18 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using Ganss.Xss;
+
+namespace DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+internal sealed class HtmlTextSanitiser : ITextSanitiser
+{
+    private static readonly HtmlSanitizer s_htmlSanitizer = new();
+
+    static HtmlTextSanitiser()
+    {
+        s_htmlSanitizer.AllowedAttributes.Add("class");
+    }
+    public SanitisedText Sanitise(string raw)
+    {
+        string output = s_htmlSanitizer.Sanitize(raw);
+        return new(output);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Sanitiser/ITextSanitiser.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Sanitiser/ITextSanitiser.cs
@@ -1,0 +1,8 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+
+namespace DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+
+public interface ITextSanitiser
+{
+    SanitisedText Sanitise(string raw);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Sanitiser/SanitisedTextResult.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/Application/TextSanitiser/Sanitiser/SanitisedTextResult.cs
@@ -1,0 +1,20 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+
+namespace DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+public sealed class SanitisedTextResult
+{
+    public string Value { get; }
+    // Should not be constructable externally to enforce clients go via ITextSanitisationHandler
+    private SanitisedTextResult(SanitisedText text)
+    {
+        Value = text.Value;
+    }
+
+    internal static SanitisedTextResult Empty()
+        => new(
+            new SanitisedText(string.Empty));
+
+    internal static SanitisedTextResult From(string value)
+        => new(
+            new SanitisedText(value));
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CompositionRoot.cs
@@ -1,4 +1,7 @@
 ﻿using DfE.Data.ComponentLibrary.Infrastructure.Persistence.CosmosDb;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DfE.GIAP.Core.Common;
@@ -8,6 +11,7 @@ public static class CompositionRoot
     {
         ArgumentNullException.ThrowIfNull(services);
         services.AddCosmosDbDependencies();
+        services.AddSingleton<ITextSanitiserHandler, TextSanitiserHandler>();
         return services;
     }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/DfE.GIAP.Core.csproj
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/DfE.GIAP.Core.csproj
@@ -6,6 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dfe.Data.Common.Infrastructure.Persistence.CosmosDb" Version="1.0.0" />
+		<PackageReference Include="HtmlSanitizer" Version="9.0.886" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
@@ -16,5 +17,6 @@
     <InternalsVisibleTo Include="DfE.GIAP.SharedTests" />
     <InternalsVisibleTo Include="DfE.GIAP.Core.UnitTests" />
 		<InternalsVisibleTo Include="DfE.GIAP.Core.IntegrationTests" />
+		<InternalsVisibleTo Include="DfE.GIAP.Web.Tests" />
 	</ItemGroup>
 </Project>

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/UpdateNewsArticle/UpdateNewsArticleRequest.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/UpdateNewsArticle/UpdateNewsArticleRequest.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
 using DfE.GIAP.Core.NewsArticles.Application.Models;
 
 namespace DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
@@ -16,8 +17,8 @@ public record UpdateNewsArticlesRequestProperties
     }
 
     public NewsArticleIdentifier Id { get; }
-    public string? Title { get; init; }
-    public string? Body { get; init; }
+    public SanitisedTextResult? Title { get; init; }
+    public SanitisedTextResult? Body { get; init; }
     public DateTime ModifiedDate { get; }
     public DateTime CreatedDate { get; }
     public bool? Pinned { get; init; }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/UpdateNewsArticle/UpdateNewsArticleUseCase.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/NewsArticles/Application/UseCases/UpdateNewsArticle/UpdateNewsArticleUseCase.cs
@@ -38,8 +38,8 @@ internal sealed class UpdateNewsArticlesRequestPropertiesMapperToNewsArticle : I
         return new()
         {
             Id = input.Id,
-            Title = input.Title ?? string.Empty,
-            Body = input.Body ?? string.Empty,
+            Title = input.Title?.Value ?? string.Empty,
+            Body = input.Body?.Value ?? string.Empty,
             Pinned = input.Pinned ?? false,
             Published = input.Published ?? false,
             CreatedDate = input.CreatedDate,

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/Admin/ManageDocuments/ManageDocumentsController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/Admin/ManageDocuments/ManageDocumentsController.cs
@@ -3,6 +3,7 @@ using DfE.GIAP.Common.Constants;
 using DfE.GIAP.Common.Enums;
 using DfE.GIAP.Common.Helpers;
 using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
 using DfE.GIAP.Core.Models;
 using DfE.GIAP.Core.Models.Common;
 using DfE.GIAP.Core.Models.Editor;
@@ -39,6 +40,7 @@ public class ManageDocumentsController : Controller
     private readonly IUseCaseRequestOnly<DeleteNewsArticleRequest> _deleteNewsArticleUseCase;
     private readonly IUseCaseRequestOnly<CreateNewsArticleRequest> _createNewsArticleUseCase;
     private readonly IUseCaseRequestOnly<UpdateNewsArticleRequest> _updateNewsArticleUseCase;
+    private readonly ITextSanitiserHandler _textSanitiserHandler;
 
     public ManageDocumentsController(
         INewsService newsService,
@@ -47,22 +49,32 @@ public class ManageDocumentsController : Controller
         IUseCase<GetNewsArticlesRequest, GetNewsArticlesResponse> getNewsArticlesUseCase,
         IUseCaseRequestOnly<DeleteNewsArticleRequest> deleteNewsArticleUseCase,
         IUseCaseRequestOnly<CreateNewsArticleRequest> createNewsArticleUseCase,
-        IUseCaseRequestOnly<UpdateNewsArticleRequest> updateNewsArticleUseCase)
+        IUseCaseRequestOnly<UpdateNewsArticleRequest> updateNewsArticleUseCase,
+        ITextSanitiserHandler textSanitiser)
     {
-        _newsService = newsService ??
-            throw new ArgumentNullException(nameof(newsService));
-        _contentService = contentService ??
-            throw new ArgumentNullException(nameof(contentService));
-        _getNewsArticleByIdUseCase = getNewsArticleByIdUseCase ??
-            throw new ArgumentNullException(nameof(getNewsArticleByIdUseCase));
-        _getNewsArticlesUseCase = getNewsArticlesUseCase ??
-            throw new ArgumentNullException(nameof(getNewsArticlesUseCase));
-        _deleteNewsArticleUseCase = deleteNewsArticleUseCase ??
-            throw new ArgumentNullException(nameof(deleteNewsArticleUseCase));
-        _createNewsArticleUseCase = createNewsArticleUseCase ??
-            throw new ArgumentNullException(nameof(createNewsArticleUseCase));
-        _updateNewsArticleUseCase = updateNewsArticleUseCase ??
-            throw new ArgumentNullException(nameof(updateNewsArticleUseCase));
+        ArgumentNullException.ThrowIfNull(newsService);
+        _newsService = newsService;
+
+        ArgumentNullException.ThrowIfNull(contentService);
+        _contentService = contentService;
+
+        ArgumentNullException.ThrowIfNull(getNewsArticleByIdUseCase);
+        _getNewsArticleByIdUseCase = getNewsArticleByIdUseCase;
+
+        ArgumentNullException.ThrowIfNull(getNewsArticlesUseCase);
+        _getNewsArticlesUseCase = getNewsArticlesUseCase;
+
+        ArgumentNullException.ThrowIfNull(deleteNewsArticleUseCase);
+        _deleteNewsArticleUseCase = deleteNewsArticleUseCase;
+
+        ArgumentNullException.ThrowIfNull(createNewsArticleUseCase);
+        _createNewsArticleUseCase = createNewsArticleUseCase;
+
+        ArgumentNullException.ThrowIfNull(updateNewsArticleUseCase);
+        _updateNewsArticleUseCase = updateNewsArticleUseCase;
+
+        ArgumentNullException.ThrowIfNull(textSanitiser);
+        _textSanitiserHandler = textSanitiser;
     }
 
     [HttpGet]
@@ -292,11 +304,10 @@ public class ManageDocumentsController : Controller
             return View("../Admin/ManageDocuments/EditNewsArticle", manageDocumentsModel);
         }
 
-        // TODO sanitisation part of Application
         UpdateNewsArticlesRequestProperties updateProperties = new(id: manageDocumentsModel.NewsArticle.Id)
         {
-            Title = SecurityHelper.SanitizeText(manageDocumentsModel.NewsArticle.Title),
-            Body = SecurityHelper.SanitizeText(manageDocumentsModel.NewsArticle.Body),
+            Title =  _textSanitiserHandler.Handle(manageDocumentsModel.NewsArticle.Title),
+            Body = _textSanitiserHandler.Handle(manageDocumentsModel.NewsArticle.Body),
             Pinned = manageDocumentsModel.NewsArticle.Pinned,
             Published = manageDocumentsModel.NewsArticle.Published,
         };

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/BaseIntegrationTest.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/BaseIntegrationTest.cs
@@ -39,7 +39,7 @@ public abstract class BaseIntegrationTest : IAsyncLifetime
     private async Task SetupAsync()
     {
         await Fixture.Database.ClearDatabaseAsync();
-        _services.AddSharedDependencies();
+        _services.AddSharedTestDependencies();
     }
 
     public async Task DisposeAsync()

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/Contents/GetContentByPageKeyUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/Contents/GetContentByPageKeyUseCaseIntegrationTests.cs
@@ -38,7 +38,7 @@ public sealed class GetContentByPageKeyUseCaseIntegrationTests : IAsyncLifetime
             .Build();
 
         IServiceCollection services = ServiceCollectionTestDoubles.Default()
-            .AddSharedDependencies()
+            .AddSharedTestDependencies()
             .RemoveAll<IConfiguration>() // replace default configuration
             .AddSingleton(configuration)
             .AddContentDependencies();

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/UpdateNewsArticle/UpdateNewsArticleUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/NewsArticles/UpdateNewsArticle/UpdateNewsArticleUseCaseIntegrationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Net;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
 using DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
 using Microsoft.Azure.Cosmos;
 
@@ -43,8 +45,8 @@ public sealed class UpdateNewsArticleUseCaseIntegrationTests : BaseIntegrationTe
 
         UpdateNewsArticlesRequestProperties requestProperties = new(seededArticle.id)
         {
-            Title = "Test tile",
-            Body = "Test body",
+            Title = SanitisedTextResult.From("Test tile"),
+            Body = SanitisedTextResult.From("Test body"),
             Pinned = requestPinned,
             Published = requestPublished,
         };
@@ -65,8 +67,8 @@ public sealed class UpdateNewsArticleUseCaseIntegrationTests : BaseIntegrationTe
 
         Assert.NotNull(updatedArticle);
         Assert.Equal(seededArticle.id, updatedArticle.id);
-        Assert.Equal(requestProperties.Title, updatedArticle.Title);
-        Assert.Equal(requestProperties.Body, updatedArticle.Body);
+        Assert.Equal(requestProperties.Title.Value, updatedArticle.Title);
+        Assert.Equal(requestProperties.Body.Value, updatedArticle.Body);
         Assert.Equal(requestProperties.Pinned, updatedArticle.Pinned);
         Assert.Equal(requestProperties.Published, updatedArticle.Published);
         Assert.InRange(updatedArticle.CreatedDate, beforeRequestCreationDateTimeUtc, beforeRequestCreationDateTimeUtc.Add(stopWatch.Elapsed));

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Common/TextSanitiser/CompositionRootTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Common/TextSanitiser/CompositionRootTests.cs
@@ -1,0 +1,25 @@
+﻿using DfE.GIAP.Core.Common;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.SharedTests;
+using DfE.GIAP.Core.SharedTests.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DfE.GIAP.Core.UnitTests.Common.TextSanitiser;
+public sealed class CompositionRootTests
+{
+    [Fact]
+    public void Registers_CompositionRoot_CanResolve_Services()
+    {
+        // Arrange
+        IServiceCollection services = ServiceCollectionTestDoubles.Default()
+            .AddSharedTestDependencies()
+            .AddFeaturesSharedDependencies();
+
+        // Act
+        IServiceProvider provider = services.BuildServiceProvider();
+
+        // Assert
+        Assert.NotNull(provider);
+        Assert.NotNull(provider.GetService<ITextSanitiserHandler>());
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Common/TextSanitiser/HtmlTextSanitiserTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Common/TextSanitiser/HtmlTextSanitiserTests.cs
@@ -1,0 +1,83 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+
+namespace DfE.GIAP.Core.UnitTests.Common.TextSanitiser;
+
+public sealed class HtmlTextSanitiserTests
+{
+    private readonly HtmlTextSanitiser _sanitiser;
+
+    public HtmlTextSanitiserTests()
+    {
+        _sanitiser = new();
+    }
+
+    [Fact]
+    public void Sanitise_RemovesScriptTags()
+    {
+        // Arrange
+        string input = "<script>alert('xss');</script><p>Hello</p>";
+
+        // Act
+        SanitisedText result = _sanitiser.Sanitise(input);
+
+        // Assert
+        Assert.Equal("<p>Hello</p>", result.Value);
+        Assert.DoesNotContain("<script>", result.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sanitise_AllowsClassAttribute()
+    {
+        // Arrange
+        string input = "<p class='highlight'>Text</p>";
+
+        // Act
+        SanitisedText result = _sanitiser.Sanitise(input);
+
+        // Assert
+        Assert.Equal("<p class=\"highlight\">Text</p>", result.Value);
+    }
+
+    [Fact]
+    public void Sanitise_RemovesDisallowedAttributes()
+    {
+        // Arrange
+        string input = "<p onclick='evil()'>Click me</p>";
+
+        // Act
+        SanitisedText result = _sanitiser.Sanitise(input);
+
+        // Assert
+        Assert.DoesNotContain("onclick", result.Value);
+        Assert.Equal("<p>Click me</p>", result.Value);
+    }
+
+    [Theory]
+    [InlineData("\r\n")]
+    [InlineData("     \r   \n ")]
+    public void Sanitise_Strips_CarriageReturns(string input)
+    {
+        // Act
+        SanitisedText result = _sanitiser.Sanitise(input!);
+
+        // Assert
+        Assert.DoesNotContain("\r", result.Value);
+        Assert.Contains("\n", result.Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\n")]
+    public void Sanitise_HandlesEmptyOrNull_Input(string? input)
+    {
+        // Act
+        SanitisedText result = _sanitiser.Sanitise(input!);
+
+        // Assert
+        string expected = input ?? string.Empty;
+        Assert.Equal(expected, result.Value);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Common/TextSanitiser/TextSanitiserHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Common/TextSanitiser/TextSanitiserHandlerTests.cs
@@ -1,0 +1,60 @@
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+
+namespace DfE.GIAP.Core.UnitTests.Common.TextSanitiser;
+public sealed class TextSanitiserHandlerTests
+{
+    [Fact]
+    public void Handle_WithNoCustomSanitisers_AppliesDefaultHtmlSanitiser()
+    {
+        // Arrange
+        TextSanitiserHandler handler = new(null!);
+
+        // Act
+        SanitisedTextResult result = handler.Handle("<script onClick=evil()>Hello</script>");
+
+        // Assert
+        Assert.DoesNotContain("script", result.Value);
+    }
+
+    [Fact]
+    public void Handle_WithCustomSanitisers_AppliesAllInOrder()
+    {
+        // Arrange
+        FakeTextToUpperCaseSanitiser testUpperCaseSanitiser = new();
+        FakeMaliciousScriptSanitiser maliciousScriptSanitiser = new();
+        TextSanitiserHandler handler = new(sanitisers: [testUpperCaseSanitiser, maliciousScriptSanitiser]);
+
+        // Act
+        SanitisedTextResult result = handler.Handle("hello");
+
+        // Assert
+        Assert.Equal("HELLO", result.Value);
+        Assert.Equal(1, testUpperCaseSanitiser.ExecutionCount);
+        Assert.Equal(1, maliciousScriptSanitiser.ExecutionCount);
+    }
+
+    internal sealed class FakeTextToUpperCaseSanitiser : ITextSanitiser
+    {
+        public int ExecutionCount { get; private set; }
+        public SanitisedText Sanitise(string raw)
+        {
+            ExecutionCount++;
+            return new(raw.ToUpper());
+        }
+    }
+
+    internal sealed class FakeMaliciousScriptSanitiser : ITextSanitiser
+    {
+        public int ExecutionCount { get; private set; }
+
+        public SanitisedText Sanitise(string raw)
+        {
+            ExecutionCount++;
+            // Simulated malicious input for testing purposes only
+            string malicious = raw + "<script>alert('xss');</script>";
+            return new(malicious);
+        }
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Contents/CompositionRootTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/Contents/CompositionRootTests.cs
@@ -27,7 +27,7 @@ public sealed class CompositionRootTests
     public void Registers_CompositionRoot_CanResolve_Services()
     {
         // Arrange
-        IServiceCollection services = ServiceCollectionTestDoubles.Default().AddSharedDependencies();
+        IServiceCollection services = ServiceCollectionTestDoubles.Default().AddSharedTestDependencies();
 
         // Act
         IServiceCollection registeredServices = CompositionRoot.AddContentDependencies(services);

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/CompositionRootTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/CompositionRootTests.cs
@@ -1,6 +1,10 @@
 ﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
 using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Core.NewsArticles.Application.UseCases.CreateNewsArticle;
+using DfE.GIAP.Core.NewsArticles.Application.UseCases.DeleteNewsArticle;
 using DfE.GIAP.Core.NewsArticles.Application.UseCases.GetNewsArticles;
+using DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
 using DfE.GIAP.Core.NewsArticles.Infrastructure.Repositories;
 using DfE.GIAP.Core.SharedTests;
 using DfE.GIAP.Core.SharedTests.TestDoubles;
@@ -23,7 +27,7 @@ public sealed class CompositionRootTests
     public void Registers_CompositionRoot_CanResolve_Services()
     {
         // Arrange
-        IServiceCollection services = ServiceCollectionTestDoubles.Default().AddSharedDependencies();
+        IServiceCollection services = ServiceCollectionTestDoubles.Default().AddSharedTestDependencies();
 
         // Act
         IServiceCollection registeredServices = CompositionRoot.AddNewsArticleDependencies(services);
@@ -35,7 +39,14 @@ public sealed class CompositionRootTests
 
         Assert.NotNull(provider.GetService<IUseCase<GetNewsArticlesRequest, GetNewsArticlesResponse>>());
         Assert.NotNull(provider.GetService<IUseCase<GetNewsArticleByIdRequest, GetNewsArticleByIdResponse>>());
+        Assert.NotNull(provider.GetService<IUseCaseRequestOnly<CreateNewsArticleRequest>>());
+        Assert.NotNull(provider.GetService<IUseCaseRequestOnly<DeleteNewsArticleRequest>>());
+        Assert.NotNull(provider.GetService<IUseCaseRequestOnly<UpdateNewsArticleRequest>>());
+
         Assert.NotNull(provider.GetService<IMapper<NewsArticleDto, NewsArticle>>());
         Assert.NotNull(provider.GetService<INewsArticleReadRepository>());
+        Assert.NotNull(provider.GetService<INewsArticleWriteRepository>());
+
+        Assert.NotNull(provider.GetService<ITextSanitiser>());
     }
 }

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/NewsArticles/UseCases/UpdateNewsArticle/UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests.cs
@@ -1,4 +1,6 @@
-﻿using DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
+﻿using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Sanitiser;
+using DfE.GIAP.Core.NewsArticles.Application.UseCases.UpdateNewsArticle;
 
 namespace DfE.GIAP.Core.UnitTests.NewsArticles.UseCases.UpdateNewsArticle;
 public sealed class UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests
@@ -43,8 +45,8 @@ public sealed class UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests
         {
             Published = true,
             Pinned = true,
-            Title = "Test tile",
-            Body = "Test body",
+            Title = SanitisedTextResult.From("Test tile"),
+            Body = SanitisedTextResult.From("Test body"),
         };
 
         // Act
@@ -52,8 +54,8 @@ public sealed class UpdateNewsArticleRequestPropertiesToNewsArticleMapperTests
 
         // Assert
         Assert.Equal(properties.Id, result.Id);
-        Assert.Equal(properties.Title, result.Title);
-        Assert.Equal(properties.Body, result.Body);
+        Assert.Equal(properties.Title.Value, result.Title);
+        Assert.Equal(properties.Body.Value, result.Body);
         Assert.Equal(properties.CreatedDate, result.CreatedDate);
         Assert.Equal(properties.ModifiedDate, result.ModifiedDate);
         Assert.Equal(properties.Pinned, result.Pinned);

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/CompositionRoot.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/CompositionRoot.cs
@@ -7,7 +7,8 @@ using Microsoft.Extensions.Logging;
 namespace DfE.GIAP.Core.SharedTests;
 public static class CompositionRoot
 {
-    public static IServiceCollection AddSharedDependencies(this IServiceCollection services)
+    // These are provided by the runtime; Logging, Configuration etc. Resolving types will fail without these as they are dependant on them
+    public static IServiceCollection AddSharedTestDependencies(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Admin/ManageDocumentsControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Admin/ManageDocumentsControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using DfE.GIAP.Common.AppSettings;
 using DfE.GIAP.Common.Enums;
 using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Common.Application.TextSanitiser.Abstraction.Handler;
 using DfE.GIAP.Core.Models.Common;
 using DfE.GIAP.Core.Models.Editor;
 using DfE.GIAP.Core.NewsArticles.Application.Models;
@@ -25,15 +26,14 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
-using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace DfE.GIAP.Web.Tests.Controllers.Admin;
 
 [Trait("Category", "Manage Documents Controller Unit Tests")]
 public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalFake>, IClassFixture<ManageDocumentsResultsFake>
 {
-    private readonly Mock<IOptions<AzureAppSettings>> _mockAzureAppSettings = new Mock<IOptions<AzureAppSettings>>();
-    private readonly Mock<ISession> _mockSession = new Mock<ISession>();
+    private readonly Mock<IOptions<AzureAppSettings>> _mockAzureAppSettings = new();
+    private readonly Mock<ISession> _mockSession = new();
     private readonly UserClaimsPrincipalFake _userClaimsPrincipalFake;
     private readonly ManageDocumentsResultsFake _manageDocumentsResultsFake;
     private readonly Mock<IContentService> _mockContentService = new();
@@ -43,6 +43,7 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
     private readonly Mock<IUseCaseRequestOnly<DeleteNewsArticleRequest>> _mockDeleteNewsArticleUseCase = new();
     private readonly Mock<IUseCaseRequestOnly<CreateNewsArticleRequest>> _mockCreateNewsArticleUseCase = new();
     private readonly Mock<IUseCaseRequestOnly<UpdateNewsArticleRequest>> _mockUpdateNewsArticleUseCase = new();
+    private readonly Mock<ITextSanitiserHandler> _mockTextSanitiser = new();
 
     public ManageDocumentsControllerTests(UserClaimsPrincipalFake userClaimsPrincipalFake, ManageDocumentsResultsFake manageDocumentsResultsFake)
     {
@@ -97,15 +98,15 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
         CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
         _mockContentService.Setup(repo => repo.GetContent(DocumentType.PlannedMaintenance)).ReturnsAsync(commonResponseBody);
 
-        var model = new ManageDocumentsViewModel { DocumentList = new Document { Id = 1, DocumentName = "Test title", DocumentId = "NewsArticle" } };
+        ManageDocumentsViewModel model = new() { DocumentList = new Document { Id = 1, DocumentName = "Test title", DocumentId = "NewsArticle" } };
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
 
         // Act
-        var result = await controller.ManageDocuments(model, string.Empty, string.Empty).ConfigureAwait(false);
+        IActionResult result = await controller.ManageDocuments(model, string.Empty, string.Empty);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal(2, viewResult.ViewData.Values.Count);
         Assert.True(viewResult.ViewData.ContainsKey("ListOfDocuments"));
     }
@@ -117,17 +118,17 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
         CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
         _mockContentService.Setup(repo => repo.GetContent(DocumentType.PlannedMaintenance)).ReturnsAsync(commonResponseBody);
 
-        var controller = GetManageDocumentsController();
-        var model = _manageDocumentsResultsFake.GetDocumentDetails();
-        var discard = "Discard";
-        var editDocument = "EditDocument";
+        ManageDocumentsController controller = GetManageDocumentsController();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetails();
+        string discard = "Discard";
+        string editDocument = "EditDocument";
 
         // Act
-        var result = await controller.ManageDocuments(model, discard, editDocument).ConfigureAwait(false);
+        IActionResult result = await controller.ManageDocuments(model, discard, editDocument);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
-        var documentData = Assert.IsType<ManageDocumentsViewModel>(viewResult.ViewData.Model).DocumentData;
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
+        CommonResponseBodyViewModel documentData = Assert.IsType<ManageDocumentsViewModel>(viewResult.ViewData.Model).DocumentData;
         Assert.Equal(commonResponseBody.Id, documentData.Id);
         Assert.Equal(2, viewResult.ViewData.Values.Count);
         Assert.True(viewResult.ViewData.ContainsKey("ListOfDocuments"));
@@ -137,29 +138,29 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
     public async Task PublishChangesInDocument_PostBackMethod()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
 
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        List<Document> documentsList = new List<Document>
+        List<Document> documentsList = new()
         {
             new Document() { Id = 1, DocumentId = "TestNewsArticle", DocumentName = "Test News Articles", SortId = 1, IsEnabled = true },
             new Document() { Id = 2, DocumentId = "PublicationSchedule", DocumentName = "Publication Schedule", SortId = 2, IsEnabled = true },
             new Document() { Id = 3, DocumentId = "PlannedMaintenance", DocumentName = "Planned Maintenance", SortId = 3, IsEnabled = true }
         };
 
-        var model = _manageDocumentsResultsFake.GetDocumentDetails();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetails();
 
         CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
 
-        var publish = "Publish";
+        string publish = "Publish";
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
         Assert.IsType<ViewResult>(result);
@@ -170,7 +171,7 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
     {
         // Arrange
         ITempDataProvider tempDataProvider = Mock.Of<ITempDataProvider>();
-        TempDataDictionaryFactory tempDataDictionaryFactory = new TempDataDictionaryFactory(tempDataProvider);
+        TempDataDictionaryFactory tempDataDictionaryFactory = new(tempDataProvider);
         ITempDataDictionary tempData = tempDataDictionaryFactory.GetTempData(new DefaultHttpContext());
 
         ManageDocumentsController controller = GetManageDocumentsController();
@@ -214,11 +215,14 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
         };
 
         _mockGetNewsArticleByIdUseCase.Setup(useCase => useCase.HandleRequestAsync(It.IsAny<GetNewsArticleByIdRequest>())).ReturnsAsync(new GetNewsArticleByIdResponse(article));
+        _mockTextSanitiser
+            .Setup((t) => t.Handle(It.IsAny<string>()))
+            .Returns((string input) => new SanitisedText(input));
 
         ManageDocumentsController controller = GetManageDocumentsController();
 
         // Act
-        IActionResult result = await controller.UpdateNewsArticle(model).ConfigureAwait(false);
+        IActionResult result = await controller.UpdateNewsArticle(model);
 
         // Assert
         ViewResult viewResult = Assert.IsType<ViewResult>(result);
@@ -232,187 +236,187 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
     public async Task Check_error_view_when_PreviewChanges_fails_to_set_pinned()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var model = _manageDocumentsResultsFake.GetDocumentDetails();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetails();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var preview = "Preview";
+        string preview = "Preview";
 
         // Act
-        var result = await controller.PreviewChanges(model, preview).ConfigureAwait(false);
+        IActionResult result = await controller.PreviewChanges(model, preview);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.UpdatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.UpdatedError, errorModel.UserErrorMessage);
     }
 
     [Fact]
     public async Task Check_error_view_when_PublishChanges_fails_to_save_draft_with_id_and_selectedNewsID()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
-        var model = _manageDocumentsResultsFake.GetDocumentDetailsWithSelectedNews();
+        CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetailsWithSelectedNews();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var publish = "";
+        string publish = string.Empty;
 
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.UpdatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.UpdatedError, errorModel.UserErrorMessage);
     }
 
     [Fact]
     public async Task Check_error_view_when_PublishChanges_fails_to_save_draft_with_id_and_no_selectedNewsID()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
-        var model = _manageDocumentsResultsFake.GetDocumentDetails();
+        CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetails();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var publish = "";
+        string publish = string.Empty;
 
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.UpdatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.UpdatedError, errorModel.UserErrorMessage);
     }
 
     [Fact]
     public async Task Check_error_view_when_PublishChanges_fails_to_save_draft_with_no_id_and_no_selectedNewsID()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
-        var model = _manageDocumentsResultsFake.GetDocumentDetailsNoID();
+        CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetailsNoID();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var publish = "";
+        string publish = string.Empty;
 
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.CreatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.CreatedError, errorModel.UserErrorMessage);
     }
 
     [Fact]
     public async Task Check_error_view_when_PublishChanges_fails_to_publish_with_id_and_selectedNewsID()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
-        var model = _manageDocumentsResultsFake.GetDocumentDetailsWithSelectedNews();
+        CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetailsWithSelectedNews();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var publish = "";
+        string publish = string.Empty;
 
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.UpdatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.UpdatedError, errorModel.UserErrorMessage);
     }
 
     [Fact]
     public async Task Check_error_view_when_PublishChanges_fails_to_publish_with_id_and_no_selectedNewsID()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
-        var model = _manageDocumentsResultsFake.GetDocumentDetails();
+        CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetails();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var publish = "";
+        string publish = string.Empty;
 
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.UpdatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.UpdatedError, errorModel.UserErrorMessage);
     }
 
     [Fact]
     public async Task Check_error_view_when_PublishChanges_fails_to_publish_with_no_id_and_no_selectedNewsID()
     {
         // Arrange
-        var user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
-        var context = new ControllerContext() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
+        System.Security.Claims.ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = _mockSession.Object } };
 
-        var commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
-        var model = _manageDocumentsResultsFake.GetDocumentDetailsNoID();
+        CommonResponseBody commonResponseBody = _manageDocumentsResultsFake.GetCommonResponseBody();
+        ManageDocumentsViewModel model = _manageDocumentsResultsFake.GetDocumentDetailsNoID();
 
         _mockContentService.Setup(repo => repo.SetDocumentToPublished(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync((CommonResponseBody)default);
         _mockContentService.Setup(repo => repo.AddOrUpdateDocument(It.IsAny<CommonRequestBody>(), It.IsAny<AzureFunctionHeaderDetails>())).ReturnsAsync(commonResponseBody);
 
-        var controller = GetManageDocumentsController();
+        ManageDocumentsController controller = GetManageDocumentsController();
         controller.ControllerContext = context;
-        var publish = "";
+        string publish = string.Empty;
 
         // Act
-        var result = await controller.PublishChanges(model, publish).ConfigureAwait(false);
+        IActionResult result = await controller.PublishChanges(model, publish);
 
         // Assert
-        var viewResult = Assert.IsType<ViewResult>(result);
+        ViewResult viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("../Admin/ManageDocuments/Error", viewResult.ViewName);
-        var errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
-        Assert.Equal(errorModel.UserErrorMessage, Messages.NewsArticle.Errors.CreatedError);
+        UserErrorViewModel errorModel = Assert.IsType<UserErrorViewModel>(viewResult.Model);
+        Assert.Equal(Messages.NewsArticle.Errors.CreatedError, errorModel.UserErrorMessage);
     }
 
     public ManageDocumentsController GetManageDocumentsController()
@@ -424,6 +428,7 @@ public class ManageDocumentsControllerTests : IClassFixture<UserClaimsPrincipalF
             _mockGetNewsArticlesUseCase.Object,
             _mockDeleteNewsArticleUseCase.Object,
             _mockCreateNewsArticleUseCase.Object,
-            _mockUpdateNewsArticleUseCase.Object);
+            _mockUpdateNewsArticleUseCase.Object,
+            _mockTextSanitiser.Object);
     }
 }


### PR DESCRIPTION
## 📌 Summary

@spanersoraferty Be good to get your opinions on this.

As part of #126 follow up. HtmlSanitiser is called in Web in different areas via a `SecurityHelper` static method. It was discussed whether this is a Presentation / Application layer concern. 
```cs
namespace DfE.GIAP.Common.Helpers
{
    public static class SecurityHelper
    {
        /// <summary>
        /// Helper to clean text/user input, wrapper around HtmlSanitizer. Will allow classes. 
        /// </summary>
        /// <param name="text">Text to clean</param>
        /// <returns>Cleaned text</returns>
        public static string SanitizeText(string text)
        {
            var sanitizer = new HtmlSanitizer();
            sanitizer.AllowedAttributes.Add("class");
            return sanitizer.Sanitize(text);
        }
    }
}

```

My concern with the current approach is we cannot be sure Web has sanitised malicious input, where user input is provided into the application-layer, unless we enforce it ourselves by applying guards at the edge e.g xss attacks. We know that Web should do this in any areas where users enter text; `News`, `Search` are the examples.

So I've implemented a abstraction that lets us define text sanitisation, carried through into request models, where it's client-provided text, guiding that text some text must be sanitised.

Types introduces as part of the public API in `Core.Common`.

```cs
// registered as a Singleton and provides  `SanitisedTextResult`  (wrapper)
// Behind the scenes, injects all custom ITextSanitisers and applies them, and applies our HtmlSanitiserDefault after.
// I've added a reference to `HtmlSanitiser` which Web has a dependency on. I've not checked for other better options just to reduce breaking change blast radius. But now it's behind the handler, we're free to vary.

public interface ITextSanitisationHandler { 
  SanitistedTextResult Handle(string input);
} 


// the client can register for their own ITextSanitiser passwords, swears, GUIDs, external links.
public interface ITextSanitser
{
  SanitistedText Sanitise(string input);
}
public readonly struct SanitisedText 
```

Our Request models now change to explicitly take `SanitisedTextResult` e.g

```cs
public string UpdateNewsArticleRequestProperties

public SanitisedTextResult? Title { get; init; }
public SanitisedTextResult? Body { get; init; }
```

 this is to ensure Web doesn't accidentally create it's own `SanitisedText` and **is required** go via `ITextSanitisationHandler` to create this type, which is `internal` and cannot be constructed externally without abusing reflection.

## 🔍 Related Issue(s)

#126 

## 🧪 Changes Made

- [x] Refactoring

## 📸 Screenshots (if applicable)


<img width="1396" height="771" alt="image" src="https://github.com/user-attachments/assets/1ac16387-2992-49e1-92fc-7b6f064fc050" />

<img width="1522" height="673" alt="image" src="https://github.com/user-attachments/assets/06b4063b-bad5-44d9-aac1-1921c5dd85b8" />


## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)