### PR TITLE
add autotagging onto main

### DIFF
--- a/.github/workflows/web-application-cicd.yml
+++ b/.github/workflows/web-application-cicd.yml
@@ -278,7 +278,6 @@ jobs:
 # Autotag on merges into patch increments
 # NOTE minor / major bumps to be done manually
   autotag:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build_unittest_package, local_integration_tests]
     permissions:
       contents: read  # Required to check out the code.


### PR DESCRIPTION
## 📌 Summary

Each time we push a commit onto `main` this will autoincrement the patch version. 

We'll then be able to generate a release off specific tags in GitHub. We should be able to still increment the minor versions and majors, by pushing a higher tag

There are ways to autogenerate release notes from commits

## 🧪 Changes Made

- [x] Other (please describe):

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)

