### PR TITLE
[DO NOT MERGE] Adapting claims from HttpContext and passing down to Domain

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/AgeLimit.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/AgeLimit.cs
@@ -1,0 +1,18 @@
+﻿namespace DfE.GIAP.Core;
+public readonly struct AgeLimit
+{
+    public AgeLimit(int low, int high)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(low);
+        ArgumentOutOfRangeException.ThrowIfNegative(high);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(high, 999);
+        Low = low;
+        High = high;
+    }
+
+    public int High { get; }
+    public int Low { get; }
+    public bool IsDefaultLimit => IsLowDefaultedOrNotSet && IsHighDefaultedOrNotSet;
+    private bool IsLowDefaultedOrNotSet => Low == 0;
+    private bool IsHighDefaultedOrNotSet => High == 0;
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/IAuthorisationContext.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/IAuthorisationContext.cs
@@ -1,0 +1,8 @@
+﻿namespace DfE.GIAP.Core;
+public interface IAuthorisationContext
+{
+    string UserId { get; }
+    int LowAge { get; }
+    int HighAge { get; }
+    bool IsAdministrator { get; }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MapAuthorisationContextToMyPupilsAuthorisationContext.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MapAuthorisationContextToMyPupilsAuthorisationContext.cs
@@ -1,0 +1,13 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+
+namespace DfE.GIAP.Core;
+internal sealed class MapAuthorisationContextToMyPupilsAuthorisationContextMapper : IMapper<IAuthorisationContext, PupilAuthorisationContext>
+{
+    public PupilAuthorisationContext Map(IAuthorisationContext input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        AgeLimit ageRange = new(input.LowAge, input.HighAge);
+        UserRole userRole = new(input.IsAdministrator);
+        return new(ageRange, userRole);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/PupilAuthorisationContext.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/PupilAuthorisationContext.cs
@@ -1,0 +1,48 @@
+﻿namespace DfE.GIAP.Core;
+public record PupilAuthorisationContext
+{
+    private readonly AgeLimit _authorisedAgeRange;
+    private readonly UserRole _userRole;
+
+    public PupilAuthorisationContext(
+        AgeLimit AgeRange,
+        UserRole role)
+    {
+        _authorisedAgeRange = AgeRange;
+        _userRole = role;
+    }
+
+    private bool IsAgeInRange(int age)
+        => age >= _authorisedAgeRange.Low &&
+            age <= _authorisedAgeRange.High;
+
+    public bool ShouldMaskPupil(Pupil pupil)
+    {
+        if (_userRole.IsAdministrator)
+        {
+            return false;
+        }
+
+        if (_authorisedAgeRange.IsDefaultLimit) // RBAC rules don't apply and should not be masked
+        {
+            return false;
+        }
+
+        if (!pupil.HasDateOfBirth)
+        {
+            return true;
+        }
+
+        if (!pupil.TryCalculateAge(out int? age) || age is null)
+        {
+            return true;
+        }
+
+        if (!IsAgeInRange(age.Value))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/UserRole.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/UserRole.cs
@@ -1,0 +1,10 @@
+﻿namespace DfE.GIAP.Core;
+public readonly struct UserRole
+{
+    public UserRole(bool isAdminisrator)
+    {
+        IsAdministrator = isAdminisrator;
+    }
+
+    public bool IsAdministrator { get; }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Helpers/HttpContextAuthorisationContextAdaptor.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Helpers/HttpContextAuthorisationContextAdaptor.cs
@@ -1,0 +1,36 @@
+﻿using DfE.GIAP.Domain.Models.User;
+using DfE.GIAP.Web.Constants;
+using System.Security.Claims;
+
+namespace DfE.GIAP.Web.Helpers;
+
+public sealed class HttpContextAuthorisationContextAdaptor : IAuthorisationContext
+{
+    public HttpContextAuthorisationContextAdaptor(IHttpContextAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        ArgumentNullException.ThrowIfNull(accessor.HttpContext);
+
+        ClaimsPrincipal user = accessor.HttpContext.User;
+
+        UserId = user.Claims.FirstOrDefault(
+            (c) => c.Type == CustomClaimTypes.UserId)?.Value ?? throw new ArgumentException("User id claim is empty");
+
+        LowAge = int.TryParse(
+            user.Claims.FirstOrDefault(
+                    (c) => c.Type == CustomClaimTypes.OrganisationLowAge)?.Value, out int lowAge)
+                ? lowAge : 0;
+
+        HighAge = int.TryParse(
+            user.Claims.FirstOrDefault(
+                    (c) => c.Type == CustomClaimTypes.OrganisationHighAge)?.Value, out int highAge)
+                ? highAge : 0;
+
+        IsAdministrator = user.IsInRole(Roles.Admin);
+    }
+
+    public string UserId { get; init; }
+    public int LowAge { get; init; }
+    public int HighAge { get; init; }
+    public bool IsAdministrator { get; init; }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/AuthorisationContextTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/AuthorisationContextTestDoubles.cs
@@ -1,0 +1,30 @@
+﻿using DfE.GIAP.Core;
+
+namespace DfE.GIAP.SharedTests.TestDoubles;
+public static class AuthorisationContextTestDoubles
+{
+    public static IAuthorisationContext Default() => new StubAuthorisationContext(Guid.NewGuid().ToString(), false, 0, 0);
+
+    internal sealed class StubAuthorisationContext : IAuthorisationContext
+    {
+        public StubAuthorisationContext(
+            string userId,
+            bool isAdmin,
+            int lowAge,
+            int highAge)
+        {
+            UserId = userId.ToString();
+            IsAdministrator = isAdmin;
+            LowAge = lowAge;
+            HighAge = highAge;
+        }
+
+        public string UserId { get; }
+
+        public int LowAge { get; }
+
+        public int HighAge { get; }
+
+        public bool IsAdministrator { get; }
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Helpers/HttpContextAuthorisationContextAdaptorTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Helpers/HttpContextAuthorisationContextAdaptorTests.cs
@@ -1,0 +1,140 @@
+﻿using DfE.GIAP.Web.Helpers;
+using DfE.GIAP.Web.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Helpers;
+
+public sealed class HttpContextAuthorisationContextTests
+{
+
+    [Fact]
+    public void Constructor_WithNullAccessor_ThrowsArgumentNullException()
+    {
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(() => new HttpContextAuthorisationContextAdaptor(null));
+    }
+
+    [Fact]
+    public void Constructor_WithNullHttpContext_ThrowsArgumentNullException()
+    {
+        // Arrange
+        Mock<IHttpContextAccessor> accessor = new();
+        accessor.Setup(a => a.HttpContext).Returns((HttpContext)null!);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(() => new HttpContextAuthorisationContextAdaptor(accessor.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithMissingUserIdClaim_ThrowsException()
+    {
+        // Arrange
+        DefaultHttpContext context = HttpContextBuilder.Create().Build();
+
+        Mock<IHttpContextAccessor> accessor = new();
+        accessor.Setup(a => a.HttpContext).Returns(context);
+
+        // Act
+        Func<HttpContextAuthorisationContextAdaptor> act = () => new(accessor.Object);
+
+        // Assert
+        Assert.Throws<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void Constructor_WithValidClaims_InitialisesPropertiesCorrectly()
+    {
+        // Arrange
+        DefaultHttpContext context = HttpContextBuilder.Create()
+            .WithUserId("user-123")
+            .WithOrganisationAgeRange(5, 16)
+            .AsAdmin()
+            .Build();
+
+        Mock<IHttpContextAccessor> accessor = new();
+        accessor.Setup(a => a.HttpContext).Returns(context);
+
+        // Act
+        HttpContextAuthorisationContextAdaptor result = new(accessor.Object);
+
+        // Assert
+        Assert.Equal("user-123", result.UserId);
+        Assert.Equal(5, result.LowAge);
+        Assert.Equal(16, result.HighAge);
+        Assert.True(result.IsAdministrator);
+    }
+
+    [Fact]
+    public void Constructor_WithMissingAgeClaims_UsesDefaults()
+    {
+        // Arrange
+        DefaultHttpContext context = HttpContextBuilder.Create().WithUserId("user").Build();
+
+        Mock<IHttpContextAccessor> accessor = new();
+        accessor.Setup(a => a.HttpContext).Returns(context);
+
+        // Act
+        HttpContextAuthorisationContextAdaptor result = new(accessor.Object);
+
+        // Assert
+        Assert.Equal("user", result.UserId);
+        Assert.Equal(0, result.LowAge);
+        Assert.Equal(0, result.HighAge);
+        Assert.False(result.IsAdministrator);
+    }
+
+    [Fact]
+    public async Task Constructor_InAsyncContext_DoesNotThrowOrMisbehave()
+    {
+        // Arrange
+        DefaultHttpContext context = HttpContextBuilder.Create()
+            .WithUserId("async")
+            .WithOrganisationAgeRange(10, 18)
+            .AsAdmin()
+            .Build();
+
+        Mock<IHttpContextAccessor> accessor = new();
+        accessor.Setup(a => a.HttpContext).Returns(context);
+
+        // Act
+        HttpContextAuthorisationContextAdaptor result = await Task.Run(() => new HttpContextAuthorisationContextAdaptor(accessor.Object));
+
+        // Assert
+        Assert.Equal("async", result.UserId);
+        Assert.Equal(10, result.LowAge);
+        Assert.Equal(18, result.HighAge);
+        Assert.True(result.IsAdministrator);
+    }
+
+    [Fact]
+    public async Task Constructor_InsideConfigureAwaitFalseContext_DoesNotThrow()
+    {
+        // Arrange
+        DefaultHttpContext context = HttpContextBuilder.Create()
+            .WithUserId("async-no-return-to-scheduling-context")
+            .WithOrganisationAgeRange(11, 17)
+            .AsAdmin()
+            .Build();
+
+        Mock<IHttpContextAccessor> accessor = new();
+        accessor.Setup(a => a.HttpContext).Returns(context);
+
+        HttpContextAuthorisationContextAdaptor? result = null;
+
+        // Act
+#pragma warning disable xUnit1030 // Do not call ConfigureAwait(false) in test method
+        await Task.Run(() =>
+        {
+            result = new HttpContextAuthorisationContextAdaptor(accessor.Object);
+        }).ConfigureAwait(false);
+#pragma warning restore xUnit1030 // Do not call ConfigureAwait(false) in test method
+
+        // Assert
+        Assert.Equal("async-no-return-to-scheduling-context", result!.UserId);
+        Assert.Equal(11, result.LowAge);
+        Assert.Equal(17, result.HighAge);
+        Assert.True(result.IsAdministrator);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/HttpContextBuilder.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/HttpContextBuilder.cs
@@ -1,0 +1,60 @@
+﻿using System.Security.Claims;
+using DfE.GIAP.Domain.Models.User;
+using DfE.GIAP.Web.Constants;
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.GIAP.Web.Tests.TestDoubles;
+
+public sealed class HttpContextBuilder
+{
+    private readonly List<Claim> _claims = [];
+    private bool _isAdmin = false;
+
+    private HttpContextBuilder() { }
+    public HttpContextBuilder WithUserId(string userId)
+    {
+        _claims.Add(new Claim(CustomClaimTypes.UserId, userId));
+        return this;
+    }
+
+    public HttpContextBuilder WithOrganisationAgeRange(int lowAge, int highAge)
+    {
+        _claims.Add(
+            new Claim(
+                CustomClaimTypes.OrganisationLowAge,
+                lowAge.ToString()));
+        _claims.Add(
+            new Claim(
+                CustomClaimTypes.OrganisationHighAge,
+                highAge.ToString()));
+        return this;
+    }
+
+    public HttpContextBuilder AsAdmin()
+    {
+        _isAdmin = true;
+        return this;
+    }
+
+    public DefaultHttpContext Build()
+    {
+        ClaimsIdentity identity = new(_claims, "TestAuth");
+
+        if (_isAdmin)
+        {
+            identity.AddClaim(
+                new Claim(
+                    ClaimTypes.Role,
+                    Roles.Admin));
+        }
+
+        ClaimsPrincipal principal = new(identity);
+
+        return new DefaultHttpContext
+        {
+            User = principal
+        };
+    }
+
+    internal static HttpContextBuilder Create() => new();
+}


### PR DESCRIPTION
This PR holds code from #139 which dealt with retrieving claims from the HttpContext and passing them down into the domain. It was decided in [adr](https://github.com/DFE-Digital/get-information-about-pupils-wiki/blob/main/adr/04-my-pupils-masked-upns.md) that MyPupils should not be masked, so I was able to pull the usage of this out.

This may be useful in the future as a starter for adapting the HttpContext.


## 📌 Summary

<!-- A brief summary of the changes introduced in this PR -->

## 🔍 Related Issue(s)

#148 

## 🧪 Changes Made

- [X] Feature added
