### PR TITLE
feat: MyPupils > GetMyPupilsUseCase 

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/Services/IAggregatePupilsForMyPupilsService.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/Services/IAggregatePupilsForMyPupilsService.cs
@@ -1,0 +1,11 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+
+namespace DfE.GIAP.Core.MyPupils.Application.Services;
+public interface IAggregatePupilsForMyPupilsApplicationService
+{
+    Task<IEnumerable<Pupil>> GetPupilsAsync(
+        IEnumerable<UniquePupilNumber> uniquePupilNumbers,
+        MyPupilsQueryOptions? queryOptions = null);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCase.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCase.cs
@@ -29,7 +29,7 @@ internal sealed class GetMyPupilsUseCase : IUseCase<GetMyPupilsRequest, GetMyPup
         UserId userId = new(request.UserId);
         User.Application.User user = await _userReadOnlyRepository.GetUserByIdAsync(userId);
 
-        if(!user.UniquePupilNumbers.Any())
+        if (!user.UniquePupilNumbers.Any())
         {
             return new GetMyPupilsResponse([]);
         }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCase.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCase.cs
@@ -29,9 +29,15 @@ internal sealed class GetMyPupilsUseCase : IUseCase<GetMyPupilsRequest, GetMyPup
         UserId userId = new(request.UserId);
         User.Application.User user = await _userReadOnlyRepository.GetUserByIdAsync(userId);
 
-        IEnumerable<PupilDto> pupilDtos =
+        if(!user.UniquePupilNumbers.Any())
+        {
+            return new GetMyPupilsResponse([]);
+        }
+
+        List<PupilDto> pupilDtos =
             (await _aggregatePupilsForMyPupilsApplicationService.GetPupilsAsync(user.UniquePupilNumbers, request.Options))
-                .Select(_mapPupilToPupilDtoMapper.Map);
+                .Select(_mapPupilToPupilDtoMapper.Map)
+                    .ToList();
 
         return new GetMyPupilsResponse(pupilDtos);
     }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCase.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCase.cs
@@ -1,0 +1,38 @@
+﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Core.MyPupils.Application.Services;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
+using DfE.GIAP.Core.User.Application;
+using DfE.GIAP.Core.User.Application.Repository;
+
+namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
+internal sealed class GetMyPupilsUseCase : IUseCase<GetMyPupilsRequest, GetMyPupilsResponse>
+{
+    private readonly IUserReadOnlyRepository _userReadOnlyRepository;
+    private readonly IAggregatePupilsForMyPupilsApplicationService _aggregatePupilsForMyPupilsApplicationService;
+    private readonly IMapper<Pupil, PupilDto> _mapPupilToPupilDtoMapper;
+
+    public GetMyPupilsUseCase(
+        IUserReadOnlyRepository userReadOnlyRepository,
+        IAggregatePupilsForMyPupilsApplicationService aggregatePupilsForMyPupilsApplicationService,
+        IMapper<Pupil, PupilDto> mapPupilToPupilDtoMapper)
+    {
+        _userReadOnlyRepository = userReadOnlyRepository;
+        _aggregatePupilsForMyPupilsApplicationService = aggregatePupilsForMyPupilsApplicationService;
+        _mapPupilToPupilDtoMapper = mapPupilToPupilDtoMapper;
+    }
+
+    public async Task<GetMyPupilsResponse> HandleRequestAsync(GetMyPupilsRequest request)
+    {
+        UserId userId = new(request.UserId);
+        User.Application.User user = await _userReadOnlyRepository.GetUserByIdAsync(userId);
+
+        IEnumerable<PupilDto> pupilDtos =
+            (await _aggregatePupilsForMyPupilsApplicationService.GetPupilsAsync(user.UniquePupilNumbers, request.Options))
+                .Select(_mapPupilToPupilDtoMapper.Map);
+
+        return new GetMyPupilsResponse(pupilDtos);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoMapper.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoMapper.cs
@@ -1,0 +1,22 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+
+namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
+internal sealed class MapPupilToPupilDtoMapper : IMapper<Pupil, PupilDto>
+{
+    public PupilDto Map(Pupil pupil)
+    {
+        return new()
+        {
+            UniquePupilNumber = pupil.Identifier.Value,
+            DateOfBirth = pupil.DateOfBirth?.ToString() ?? string.Empty,
+            Forename = pupil.Forename,
+            Surname = pupil.Surname,
+            Sex = pupil.Sex,
+            IsPupilPremium = pupil.IsOfPupilType(PupilType.PupilPremium),
+            LocalAuthorityCode = pupil.LocalAuthorityCode,
+        };
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoMapper.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoMapper.cs
@@ -8,6 +8,7 @@ internal sealed class MapPupilToPupilDtoMapper : IMapper<Pupil, PupilDto>
 {
     public PupilDto Map(Pupil pupil)
     {
+        ArgumentNullException.ThrowIfNull(pupil);
         return new()
         {
             UniquePupilNumber = pupil.Identifier.Value,

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/GetMyPupilsRequest.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/GetMyPupilsRequest.cs
@@ -1,0 +1,5 @@
+﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+
+namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+public record GetMyPupilsRequest(string UserId, MyPupilsQueryOptions? Options = null) : IUseCaseRequest<GetMyPupilsResponse>;

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/MyPupilsQueryOptions.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/MyPupilsQueryOptions.cs
@@ -6,5 +6,5 @@ public record MyPupilsQueryOptions(OrderPupilsBy Order, PageNumber Page)
             Order: new OrderPupilsBy(
                 field: string.Empty,
                 SortDirection.Default),
-            Page: new PageNumber(1));
+            Page: PageNumber.Default);
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/MyPupilsQueryOptions.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/MyPupilsQueryOptions.cs
@@ -1,7 +1,7 @@
 ﻿namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
 public record MyPupilsQueryOptions(OrderPupilsBy Order, PageNumber Page)
 {
-    internal static MyPupilsQueryOptions Default()
+    public static MyPupilsQueryOptions Default()
         => new(
             Order: new OrderPupilsBy(
                 field: string.Empty,

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/MyPupilsQueryOptions.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/MyPupilsQueryOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+public record MyPupilsQueryOptions(OrderPupilsBy Order, PageNumber Page)
+{
+    internal static MyPupilsQueryOptions Default()
+        => new(
+            Order: new OrderPupilsBy(
+                field: string.Empty,
+                SortDirection.Default),
+            Page: new PageNumber(1));
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/OrderPupilsBy.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/OrderPupilsBy.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Azure.Cosmos.Serialization.HybridRow.Schemas;
+
+namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+public record OrderPupilsBy
+{
+    // TODO Expression<Func<T for choosing a field?
+    public OrderPupilsBy(
+        string field,
+        SortDirection direction)
+    {
+        Field = field ?? string.Empty;
+        Direction = direction;
+    }
+
+    public string Field { get; }
+    public SortDirection Direction { get; }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/PageNumber.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/PageNumber.cs
@@ -1,0 +1,13 @@
+﻿namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+public readonly struct PageNumber
+{
+    public PageNumber(int page)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(page, 1);
+        Value = page;
+    }
+
+    public int Value { get; }
+
+    public static PageNumber Page(int page) => new(page);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/PageNumber.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/PageNumber.cs
@@ -9,5 +9,6 @@ public readonly struct PageNumber
 
     public int Value { get; }
 
+    public static PageNumber Default => Page(1);
     public static PageNumber Page(int page) => new(page);
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/SortDirection.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Request/SortDirection.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+public enum SortDirection
+{
+    Ascending,
+    Descending,
+    Default
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Response/GetMyPupilsResponse.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Response/GetMyPupilsResponse.cs
@@ -1,0 +1,2 @@
+﻿namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+public record GetMyPupilsResponse(IEnumerable<PupilDto> Pupils);

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Response/PupilDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/GetMyPupils/Response/PupilDto.cs
@@ -1,0 +1,11 @@
+﻿namespace DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+public record PupilDto
+{
+    public required string UniquePupilNumber { get; init; }
+    public required string Forename { get; init; }
+    public required string Surname { get; init; }
+    public required string DateOfBirth { get; init; }
+    public required string Sex { get; init; }
+    public required bool IsPupilPremium { get; init; }
+    public required int LocalAuthorityCode { get; init; }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
@@ -1,5 +1,9 @@
 ﻿using DfE.GIAP.Core.Common.Application;
 using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Core.MyPupils.Application.Services;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
 using DfE.GIAP.Core.MyPupils.Domain.Entities;
 using DfE.GIAP.Core.User.Application.Repository;
 using DfE.GIAP.Core.User.Infrastructure.Repository;
@@ -14,7 +18,17 @@ public static class CompositionRoot
         ArgumentNullException.ThrowIfNull(services);
 
         services
+            .AddMyPupilsApplication()
             .AddMyPupilsInfrastructure();
+
+        return services;
+    }
+
+    private static IServiceCollection AddMyPupilsApplication(this IServiceCollection services)
+    {
+        services
+            .AddScoped<IUseCase<GetMyPupilsRequest, GetMyPupilsResponse>, GetMyPupilsUseCase>()
+            .AddSingleton<IMapper<Pupil, PupilDto>, MapPupilToPupilDtoMapper>()
 
         return services;
     }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
@@ -1,9 +1,9 @@
 ﻿using DfE.GIAP.Core.Common.Application;
 using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Core.MyPupils.Application.Services;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
-using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
 using DfE.GIAP.Core.MyPupils.Domain.Entities;
 using DfE.GIAP.Core.User.Application.Repository;
 using DfE.GIAP.Core.User.Infrastructure.Repository;

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
@@ -28,7 +28,7 @@ public static class CompositionRoot
     {
         services
             .AddScoped<IUseCase<GetMyPupilsRequest, GetMyPupilsResponse>, GetMyPupilsUseCase>()
-            .AddSingleton<IMapper<Pupil, PupilDto>, MapPupilToPupilDtoMapper>()
+            .AddSingleton<IMapper<Pupil, PupilDto>, MapPupilToPupilDtoMapper>();
 
         return services;
     }

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsRequestTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsRequestTests.cs
@@ -1,0 +1,41 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
+public sealed class GetMyPupilsRequestTests
+{
+    [Theory]
+    [InlineData(SortDirection.Ascending)]
+    [InlineData(SortDirection.Descending)]
+    public void Constructor_SetsUserIdAndOptions(SortDirection sortDirection)
+    {
+        // Arrange
+        const string userId = "user";
+
+        MyPupilsQueryOptions options = new(
+            new OrderPupilsBy("Surname", sortDirection),
+            PageNumber.Page(2));
+
+        // Act
+        GetMyPupilsRequest request = new(userId, options);
+
+        // Assert
+        Assert.Equal(userId, request.UserId);
+        Assert.Equal("Surname", request.Options!.Order.Field);
+        Assert.Equal(sortDirection, request.Options.Order.Direction);
+        Assert.Equal(2, request.Options.Page.Value);
+    }
+
+    [Fact]
+    public void Constructor_AllowsNullOptions()
+    {
+        // Arrange
+        const string userId = "user";
+
+        // Act
+        GetMyPupilsRequest request = new(userId);
+
+        // Assert
+        Assert.Equal(userId, request.UserId);
+        Assert.Null(request.Options);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
@@ -1,5 +1,4 @@
-﻿using Bogus;
-using DfE.GIAP.Core.Common.CrossCutting;
+﻿using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Core.MyPupils.Application.Services;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
@@ -12,7 +11,6 @@ using DfE.GIAP.Core.UnitTests.TestDoubles;
 using DfE.GIAP.Core.User.Application;
 using DfE.GIAP.Core.User.Application.Repository;
 using DfE.GIAP.SharedTests.TestDoubles;
-using Microsoft.Azure.Cosmos;
 
 namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
 public sealed class GetMyPupilsUseCaseTests
@@ -34,18 +32,8 @@ public sealed class GetMyPupilsUseCaseTests
         Mock<IAggregatePupilsForMyPupilsApplicationService> aggregateServiceMock = AggregatePupilsForMyPupilsServiceTestDoubles.MockFor(pupils, user.UniquePupilNumbers);
 
         Mock<IMapper<Pupil, PupilDto>> mockMapper = MapperTestDoubles.Default<Pupil, PupilDto>();
-
         List<PupilDto> pupilDtos = PupilDtoTestDoubles.GenerateWithUniquePupilNumbers(pupils.Select(t => t.Identifier));
-
-        Dictionary<Pupil, PupilDto> mappings = pupils
-            .Zip(pupilDtos, (pupil, dto) => new
-            {
-                pupil,
-                dto
-            })
-            .ToDictionary(x => x.pupil, x => x.dto);
-
-        mockMapper.MockForMany(mappings);
+        mockMapper.MockForMany(pupils, pupilDtos);
 
         GetMyPupilsRequest request = new(user.UserId.Value);
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
@@ -26,7 +26,7 @@ public sealed class GetMyPupilsUseCaseTests
         User.Application.User user = new(userId, upns);
 
         Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user, userId);
-       
+
         List<Pupil> pupils =
             upns.Select((upn) => PupilBuilder.CreateBuilder(upn).Build())
                 .ToList();
@@ -79,7 +79,7 @@ public sealed class GetMyPupilsUseCaseTests
         Mock<IAggregatePupilsForMyPupilsApplicationService> mockAggregateService = AggregatePupilsForMyPupilsServiceTestDoubles.Default();
 
         Mock<IMapper<Pupil, PupilDto>> mockMapper = MapperTestDoubles.Default<Pupil, PupilDto>();
-        
+
         // Act
         GetMyPupilsUseCase sut = new(
             userRepoMock.Object,
@@ -99,6 +99,6 @@ public sealed class GetMyPupilsUseCaseTests
             t => t.GetPupilsAsync(Enumerable.Empty<UniquePupilNumber>(), It.IsAny<MyPupilsQueryOptions>()), Times.Never);
 
         mockMapper.Verify(t => t.Map(It.IsAny<Pupil>()), Times.Never);
-        
+
     }
 }

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
@@ -1,0 +1,104 @@
+﻿using Bogus;
+using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Core.MyPupils.Application.Services;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Core.SharedTests.TestDoubles;
+using DfE.GIAP.Core.UnitTests.MyPupils.TestDoubles;
+using DfE.GIAP.Core.UnitTests.TestDoubles;
+using DfE.GIAP.Core.User.Application;
+using DfE.GIAP.Core.User.Application.Repository;
+using DfE.GIAP.SharedTests.TestDoubles;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
+public sealed class GetMyPupilsUseCaseTests
+{
+    [Fact]
+    public async Task HandleRequestAsync_ReturnsMappedPupils()
+    {
+        // Arrange
+        UserId userId = UserIdTestDoubles.Default();
+        GetMyPupilsRequest request = new(userId.Value);
+        List<UniquePupilNumber> upns = UniquePupilNumberTestDoubles.Generate(count: 3);
+        User.Application.User user = new(userId, upns);
+
+        Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user, userId);
+       
+        List<Pupil> pupils =
+            upns.Select((upn) => PupilBuilder.CreateBuilder(upn).Build())
+                .ToList();
+
+        Mock<IAggregatePupilsForMyPupilsApplicationService> aggregateServiceMock = AggregatePupilsForMyPupilsServiceTestDoubles.MockFor(pupils, upns);
+
+        Mock<IMapper<Pupil, PupilDto>> mockMapper = MapperTestDoubles.Default<Pupil, PupilDto>();
+        List<PupilDto> pupilDtos = PupilDtoTestDoubles.GenerateWithUniquePupilNumbers(pupils.Select(t => t.Identifier));
+        for (int index = 0; index < pupils.Count; index++)
+        {
+            mockMapper
+                .Setup(m => m.Map(pupils[index]))
+                .Returns(pupilDtos[index])
+                .Verifiable();
+        }
+
+        // Act
+        GetMyPupilsUseCase sut = new(
+            userRepoMock.Object,
+            aggregateServiceMock.Object,
+            mockMapper.Object);
+
+        GetMyPupilsResponse result = await sut.HandleRequestAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(pupilDtos.Count, result.Pupils.Count());
+        Assert.Equivalent(result.Pupils, pupilDtos);
+
+        userRepoMock.Verify(repo =>
+            repo.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+
+        aggregateServiceMock.Verify(
+            t => t.GetPupilsAsync(upns, It.IsAny<MyPupilsQueryOptions>()), Times.Once);
+
+        mockMapper.Verify(
+            t => t.Map(It.IsAny<Pupil>()), Times.Exactly(pupils.Count));
+    }
+
+    [Fact]
+    public async Task HandleRequestAsync_WithEmptyPupilList_ReturnsEmptyResponse()
+    {
+        // Arrange
+        UserId userId = UserIdTestDoubles.Default();
+        GetMyPupilsRequest request = new(userId.Value);
+        User.Application.User user = new(userId, []);
+
+        Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user, userId);
+
+        Mock<IAggregatePupilsForMyPupilsApplicationService> mockAggregateService = AggregatePupilsForMyPupilsServiceTestDoubles.Default();
+
+        Mock<IMapper<Pupil, PupilDto>> mockMapper = MapperTestDoubles.Default<Pupil, PupilDto>();
+        
+        // Act
+        GetMyPupilsUseCase sut = new(
+            userRepoMock.Object,
+            mockAggregateService.Object,
+            mockMapper.Object);
+
+        GetMyPupilsResponse result = await sut.HandleRequestAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result.Pupils);
+
+        userRepoMock.Verify(repo =>
+            repo.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+
+        mockAggregateService.Verify(
+            t => t.GetPupilsAsync(Enumerable.Empty<UniquePupilNumber>(), It.IsAny<MyPupilsQueryOptions>()), Times.Never);
+
+        mockMapper.Verify(t => t.Map(It.IsAny<Pupil>()), Times.Never);
+        
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoTests.cs
@@ -1,0 +1,96 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Core.UnitTests.MyPupils.TestDoubles;
+using DfE.GIAP.SharedTests.TestDoubles;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
+
+public sealed class MapPupilToPupilDtoMapperTests
+{
+    [Fact]
+    public void Map_ValidPupil_ReturnsExpectedDto()
+    {
+        // Arrange
+        UniquePupilNumber uniquePupilNumber = UniquePupilNumberTestDoubles.Generate();
+        DateTime dob = DateTimeTestDoubles.GenerateDateOfBirthForAgeOf(10);
+        Pupil pupil =
+            PupilBuilder.CreateBuilder(uniquePupilNumber)
+            .WithFirstName("John")
+            .WithSurname("Doe")
+            .WithDateOfBirth(dob)
+            .WithSex(Sex.Male)
+            .WithPupilType(PupilType.PupilPremium)
+            .WithLocalAuthorityCode(new LocalAuthorityCode(200))
+            .Build();
+
+        MapPupilToPupilDtoMapper mapper = new();
+
+        // Act
+        PupilDto result = mapper.Map(pupil);
+
+        // Assert
+        Assert.Equal(uniquePupilNumber.Value, result.UniquePupilNumber);
+        Assert.Equal("John", result.Forename);
+        Assert.Equal("Doe", result.Surname);
+        Assert.Equal(dob.ToString("yyyy-MM-dd"), result.DateOfBirth);
+        Assert.Equal("M", result.Sex);
+        Assert.True(result.IsPupilPremium);
+        Assert.Equal(200, result.LocalAuthorityCode);
+    }
+
+    [Fact]
+    public void Map_PupilWithNullDateOfBirth_ReturnsEmptyDateOfBirth()
+    {
+        // Arrange
+        Pupil pupil =
+            PupilBuilder.CreateBuilder(UniquePupilNumberTestDoubles.Generate())
+                .WithDateOfBirth(null!)
+                .Build();
+
+        MapPupilToPupilDtoMapper mapper = new();
+
+        // Act
+        PupilDto result = mapper.Map(pupil);
+
+        // Assert
+        Assert.Equal(string.Empty, result.DateOfBirth);
+    }
+
+    [Fact]
+    public void Map_PupilWithNullSex_ReturnsEmptySex()
+    {
+        // Arrange
+        Pupil pupil =
+            PupilBuilder.CreateBuilder(UniquePupilNumberTestDoubles.Generate())
+                .WithSex(null!)
+                .Build();
+
+        MapPupilToPupilDtoMapper mapper = new();
+
+        // Act
+        PupilDto result = mapper.Map(pupil);
+
+        // Assert
+        Assert.Equal(string.Empty, result.Sex);
+    }
+
+    [Fact]
+    public void Map_PupilNotPupilPremium_ReturnsFalseForIsPupilPremium()
+    {
+        // Arrange
+        Pupil pupil =
+            PupilBuilder.CreateBuilder(UniquePupilNumberTestDoubles.Generate())
+                .WithPupilType(PupilType.NationalPupilDatabase)
+                .Build();
+
+        MapPupilToPupilDtoMapper mapper = new();
+
+        // Act
+        PupilDto result = mapper.Map(pupil);
+
+        // Assert
+        Assert.False(result.IsPupilPremium);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/MapPupilToPupilDtoTests.cs
@@ -41,6 +41,19 @@ public sealed class MapPupilToPupilDtoMapperTests
     }
 
     [Fact]
+    public void Map_ThrowsNull_If_Pupil_Is_Null()
+    {
+        Pupil? pupil = null;
+        MapPupilToPupilDtoMapper mapper = new();
+
+        // Act
+        Func<PupilDto> act = () => mapper.Map(pupil!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
     public void Map_PupilWithNullDateOfBirth_ReturnsEmptyDateOfBirth()
     {
         // Arrange

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/MyPupilsQueryOptions.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/MyPupilsQueryOptions.cs
@@ -1,0 +1,17 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
+public sealed class MyPupilsQueryOptionsTests
+{
+    [Fact]
+    public void Default_ReturnsExpectedDefaults()
+    {
+        // Act
+        MyPupilsQueryOptions result = MyPupilsQueryOptions.Default();
+
+        // Assert
+        OrderPupilsBy expectedOrder = new(field: string.Empty, SortDirection.Default);
+        Assert.Equal(expectedOrder, result.Order);
+        Assert.Equal(PageNumber.Default, result.Page);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/OrderPupilsByTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/OrderPupilsByTests.cs
@@ -1,0 +1,27 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
+public class OrderPupilsByTests
+{
+    [Fact]
+    public void Constructor_SetsFieldAndDirection()
+    {
+        // Act
+        OrderPupilsBy order = new(field: "Forename", direction: SortDirection.Ascending);
+
+        // Assert
+        Assert.Equal("Forename", order.Field);
+        Assert.Equal(SortDirection.Ascending, order.Direction);
+    }
+
+    [Fact]
+    public void Constructor_AllowsNullField_AndDefaultsToEmpty()
+    {
+        // Act
+        OrderPupilsBy order = new(field: null!, direction: SortDirection.Descending);
+
+        // Assert
+        Assert.Equal(string.Empty, order.Field);
+        Assert.Equal(SortDirection.Descending, order.Direction);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/PageNumberTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/PageNumberTests.cs
@@ -1,0 +1,34 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.GetMyPupils;
+public class PageNumberTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_Throws_WhenPageIsLessThanOne(int invalidPage)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PageNumber(invalidPage));
+    }
+
+    [Fact]
+    public void Constructor_SetsValue_WhenValid()
+    {
+        // Act
+        PageNumber page = new(3);
+
+        // Assert
+        Assert.Equal(3, page.Value);
+    }
+
+    [Fact]
+    public void Page_StaticMethod_ReturnsExpectedValue()
+    {
+        // Act
+        PageNumber page = PageNumber.Page(5);
+
+        // Assert
+        Assert.Equal(5, page.Value);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/CompositionRootTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/CompositionRootTests.cs
@@ -1,5 +1,9 @@
-﻿using DfE.GIAP.Core.Common.CrossCutting;
+﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Core.MyPupils;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
 using DfE.GIAP.Core.SharedTests;
 using DfE.GIAP.Core.SharedTests.TestDoubles;
 using DfE.GIAP.Core.User.Application.Repository;
@@ -32,6 +36,9 @@ public sealed class CompositionRootTests
 
         // Assert
         Assert.NotNull(provider);
+
+        // Waiting on the AggregateService impl Assert.NotNull(provider.GetService<IUseCase<GetMyPupilsRequest, GetMyPupilsResponse>>());
+        Assert.NotNull(provider.GetService<IMapper<Pupil, PupilDto>>());
 
         Assert.NotNull(provider.GetService<IUserReadOnlyRepository>());
         Assert.NotNull(provider.GetService<IMapper<UserDto, User.Application.User>>());

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/AggregatePupilsForMyPupilsServiceTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/AggregatePupilsForMyPupilsServiceTestDoubles.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DfE.GIAP.Core.MyPupils.Application.Services;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
+using DfE.GIAP.Core.MyPupils.Domain.Entities;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+
+namespace DfE.GIAP.Core.UnitTests.TestDoubles;
+internal static class AggregatePupilsForMyPupilsServiceTestDoubles
+{
+    internal static Mock<IAggregatePupilsForMyPupilsApplicationService> Default() => new();
+
+    internal static Mock<IAggregatePupilsForMyPupilsApplicationService> MockFor(IEnumerable<Pupil> pupils, IEnumerable<UniquePupilNumber> matchUpns)
+    {
+        Mock<IAggregatePupilsForMyPupilsApplicationService> mockService = Default();
+
+        mockService.Setup(
+                (service) => service.GetPupilsAsync(matchUpns, It.IsAny<MyPupilsQueryOptions>()))
+            .ReturnsAsync(pupils)
+            .Verifiable();
+
+        return mockService;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/UserReadOnlyRepositoryTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/UserReadOnlyRepositoryTestDoubles.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DfE.GIAP.Core.User.Application;
+using DfE.GIAP.Core.User.Application.Repository;
+
+namespace DfE.GIAP.Core.UnitTests.TestDoubles;
+internal static class UserReadOnlyRepositoryTestDoubles
+{
+    internal static Mock<IUserReadOnlyRepository> Default() => new();
+
+    internal static Mock<IUserReadOnlyRepository> MockForGetUserById(User.Application.User stub, UserId? userId = null)
+    {
+        Mock<IUserReadOnlyRepository> repoMock = Default();
+
+        UserId matchUserId = userId is null ? It.IsAny<UserId>() : userId;
+
+        repoMock.Setup(t => t.GetUserByIdAsync(
+                matchUserId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stub)
+            .Verifiable();
+
+        return repoMock;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/MapperTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/MapperTestDoubles.cs
@@ -23,8 +23,6 @@ public static class MapperTestDoubles
     }
 }
 
-
-
 public static class MapperTestDoublesExtensions
 {
     public static Mock<IMapper<TIn, TOut>> MockForMany<TIn, TOut>(

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/MapperTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/MapperTestDoubles.cs
@@ -22,3 +22,24 @@ public static class MapperTestDoubles
         return mapper;
     }
 }
+
+
+
+public static class MapperTestDoublesExtensions
+{
+    public static Mock<IMapper<TIn, TOut>> MockForMany<TIn, TOut>(
+        this Mock<IMapper<TIn, TOut>> mapper,
+        Dictionary<TIn, TOut> mappings) where TIn : notnull
+    {
+        foreach (KeyValuePair<TIn, TOut> kvp in mappings)
+        {
+            mapper
+                .Setup(m => m.Map(kvp.Key))
+                .Returns(kvp.Value)
+                .Verifiable();
+        }
+
+        return mapper;
+    }
+}
+

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/MapperTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/MapperTestDoubles.cs
@@ -41,5 +41,22 @@ public static class MapperTestDoublesExtensions
 
         return mapper;
     }
+
+    public static Mock<IMapper<TIn, TOut>> MockForMany<TIn, TOut>(
+        this Mock<IMapper<TIn, TOut>> mapper,
+        List<TIn> inputs,
+        List<TOut> outputs) where TIn : notnull
+    {
+        if (inputs.Count != outputs.Count)
+        {
+            throw new ArgumentException("Inputs and outputs must have the same number of elements.");
+        }
+
+        Dictionary<TIn, TOut> mappings = inputs
+            .Zip(outputs, (input, output) => new { input, output })
+            .ToDictionary(x => x.input, x => x.output);
+
+        return mapper.MockForMany(mappings);
+    }
 }
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/PupilDtoTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/PupilDtoTestDoubles.cs
@@ -42,7 +42,9 @@ public static class PupilDtoTestDoubles
         Faker<PupilDto> faker = new();
         faker.StrictMode(true);
         faker.RuleFor(t => t.UniquePupilNumber, (f) => UniquePupilNumberTestDoubles.Generate().Value);
-        faker.RuleFor(t => t.DateOfBirth, (f) => DateTimeTestDoubles.GenerateDateOfBirthForAgeOf(f.Random.Number(5, 18)).ToString("yyyy-MM-dd"));
+        faker.RuleFor(t => t.DateOfBirth, (f)
+            => new DateOfBirth(
+                DateTimeTestDoubles.GenerateDateOfBirthForAgeOf(f.Random.Number(5, 18))).ToString());
         faker.RuleFor(t => t.Forename, (f) => f.Name.FirstName());
         faker.RuleFor(t => t.Surname, (f) => f.Name.LastName());
         faker.RuleFor(t => t.LocalAuthorityCode, (f) => f.Random.Number(0, 999));

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/PupilDtoTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/PupilDtoTestDoubles.cs
@@ -1,0 +1,53 @@
+﻿using Bogus;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+
+namespace DfE.GIAP.SharedTests.TestDoubles;
+public static class PupilDtoTestDoubles
+{
+
+    public static PupilDto Generate() => Generate(1).Single();
+
+    public static List<PupilDto> Generate(int count)
+    {
+        return CreateGenerator().Generate(count);
+    }
+
+    public static List<PupilDto> GenerateWithUniquePupilNumbers(IEnumerable<UniquePupilNumber> uniquePupilNumbers)
+    {
+        Faker<PupilDto> generator = CreateGenerator();
+        List<PupilDto> output = [];
+
+        uniquePupilNumbers.ToList().ForEach(upn =>
+        {
+            PupilDto generatedDefault = generator.Generate();
+            PupilDto outputPupil = new()
+            {
+                UniquePupilNumber = upn.Value,
+                Sex = generatedDefault.Sex,
+                Surname = generatedDefault.Surname,
+                Forename = generatedDefault.Forename,
+                DateOfBirth = generatedDefault.DateOfBirth,
+                IsPupilPremium = generatedDefault.IsPupilPremium,
+                LocalAuthorityCode = generatedDefault.LocalAuthorityCode,
+            };
+            output.Add(outputPupil);
+        });
+
+        return output;
+    }
+
+    private static Faker<PupilDto> CreateGenerator()
+    {
+        Faker<PupilDto> faker = new();
+        faker.StrictMode(true);
+        faker.RuleFor(t => t.UniquePupilNumber, (f) => UniquePupilNumberTestDoubles.Generate().Value);
+        faker.RuleFor(t => t.DateOfBirth, (f) => DateTimeTestDoubles.GenerateDateOfBirthForAgeOf(f.Random.Number(5, 18)).ToString("yyyy-MM-dd"));
+        faker.RuleFor(t => t.Forename, (f) => f.Name.FirstName());
+        faker.RuleFor(t => t.Surname, (f) => f.Name.LastName());
+        faker.RuleFor(t => t.LocalAuthorityCode, (f) => f.Random.Number(0, 999));
+        faker.RuleFor(t => t.Sex, (f) => f.PickRandom(Sex.Female.ToString(), Sex.Male.ToString()));
+        faker.RuleFor(t => t.IsPupilPremium, (f) => f.Random.Bool());
+        return faker;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UserTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UserTestDoubles.cs
@@ -1,0 +1,21 @@
+﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Core.User.Application;
+
+namespace DfE.GIAP.SharedTests.TestDoubles;
+public static class UserTestDoubles
+{
+    public static User Default()
+    {
+        UserId userId = UserIdTestDoubles.Default();
+        List<UniquePupilNumber> upns = UniquePupilNumberTestDoubles.Generate(count: 10);
+        User user = new(userId, upns);
+        return user;
+    }
+
+    public static User WithEmptyUpns()
+    {
+        UserId userId = UserIdTestDoubles.Default();
+        User user = new(userId, []);
+        return user;
+    }
+}


### PR DESCRIPTION
## 📌 Summary

Following on from breaking up #139 this PR introduces the `GetMyPupilsUseCase` and contracts which is the UseCase used to retrieve pupils in the users pupil list.

## 🔍 Related Issue(s)

#148 

## 🧪 Changes Made

- [x] Feature added

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)