### PR TITLE
feat: MyPupils > DeletePupilsFromMyPupilsUseCase

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsRequest.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsRequest.cs
@@ -1,0 +1,7 @@
+﻿using DfE.GIAP.Core.Common.Application;
+
+namespace DfE.GIAP.Core.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
+public record DeletePupilsFromMyPupilsRequest(
+    string UserId,
+    IEnumerable<string> DeletePupilUpns,
+    bool DeleteAll) : IUseCaseRequest;

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsUseCase.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsUseCase.cs
@@ -1,0 +1,49 @@
+﻿using DfE.GIAP.Core.Common.Application;
+using DfE.GIAP.Core.MyPupils.Application.Extensions;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Core.User.Application;
+using DfE.GIAP.Core.User.Application.Repository;
+
+namespace DfE.GIAP.Core.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
+internal sealed class DeletePupilsFromMyPupilsUseCase : IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>
+{
+    private readonly IUserReadOnlyRepository _userReadOnlyRepository;
+    private readonly IUserWriteRepository _userWriteRepository;
+
+    public DeletePupilsFromMyPupilsUseCase(
+        IUserReadOnlyRepository userReadOnlyRepository,
+        IUserWriteRepository userWriteRepository)
+    {
+        _userReadOnlyRepository = userReadOnlyRepository;
+        _userWriteRepository = userWriteRepository;
+    }
+
+    public async Task HandleRequestAsync(DeletePupilsFromMyPupilsRequest request)
+    {
+        UserId userId = new(request.UserId);
+
+        if (request.DeleteAll)
+        {
+            await _userWriteRepository.SaveMyPupilsAsync(userId, []);
+            return;
+        }
+
+        User.Application.User user = await _userReadOnlyRepository.GetUserByIdAsync(userId);
+
+        IEnumerable<string> userMyPupilsUpns = user.UniquePupilNumbers.Select(t => t.Value);
+
+        if (request.DeletePupilUpns.All(deleteUpn => !userMyPupilsUpns.Contains(deleteUpn)))
+        {
+            throw new ArgumentException($"None of the pupil identifiers {string.Join(',', request.DeletePupilUpns)} are part of the User {userId.Value} MyPupils");
+        }
+
+        List<UniquePupilNumber> updatedMyPupilsAfterDelete =
+            userMyPupilsUpns
+                .Where(upn => !request.DeletePupilUpns.Contains(upn))
+                .ToUniquePupilNumbers()
+                .Distinct()
+                .ToList();
+
+        await _userWriteRepository.SaveMyPupilsAsync(userId, updatedMyPupilsAfterDelete);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/CompositionRoot.cs
@@ -9,6 +9,7 @@ using DfE.GIAP.Core.MyPupils.Application.Search.Provider;
 using DfE.GIAP.Core.MyPupils.Application.Services;
 using DfE.GIAP.Core.MyPupils.Application.Services.AggregatePupilsForMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.Services.AggregatePupilsForMyPupils.Mapper;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
@@ -39,6 +40,7 @@ public static class CompositionRoot
     {
         services
             .AddScoped<IUseCase<GetMyPupilsRequest, GetMyPupilsResponse>, GetMyPupilsUseCase>()
+            .AddScoped<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>, DeletePupilsFromMyPupilsUseCase>()
             .AddSingleton<IMapper<Pupil, PupilDto>, MapPupilToPupilDtoMapper>()
             .AddScoped<IAggregatePupilsForMyPupilsApplicationService, TempAggregatePupilsForMyPupilsApplicationService>()
             .AddSingleton<IMapper<DecoratedSearchIndexDto, Pupil>, MapDecoratedSearchIndexDtoToPupilMapper>();

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/User/Infrastructure/Repository/Dtos/MyPupilsDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/User/Infrastructure/Repository/Dtos/MyPupilsDto.cs
@@ -1,4 +1,4 @@
-﻿namespace DfE.GIAP.Core.User.Infrastructure.Repository;
+﻿namespace DfE.GIAP.Core.User.Infrastructure.Repository.Dtos;
 public sealed class MyPupilsDto
 {
     public IEnumerable<MyPupilsItemDto> Pupils { get; set; } = [];

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/User/Infrastructure/Repository/Dtos/MyPupilsItemDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/User/Infrastructure/Repository/Dtos/MyPupilsItemDto.cs
@@ -1,4 +1,4 @@
-﻿namespace DfE.GIAP.Core.User.Infrastructure.Repository;
+﻿namespace DfE.GIAP.Core.User.Infrastructure.Repository.Dtos;
 public sealed class MyPupilsItemDto
 {
     public string UPN { get; set; } = string.Empty;

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
@@ -116,7 +116,7 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
         [
             _context.myPupilUpns[0].Value,
             _context.myPupilUpns[4].Value,
-            _context.myPupilUpns[_context.myPupilUpns.Count-1].Value
+            _context.myPupilUpns[_context.myPupilUpns.Count - 1].Value
         ];
 
         DeletePupilsFromMyPupilsRequest request = new(

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
@@ -1,0 +1,166 @@
+﻿using DfE.GIAP.Core.IntegrationTests.Fixture.CosmosDb;
+using DfE.GIAP.Core.IntegrationTests.Fixture.SearchIndex;
+using DfE.GIAP.Core.MyPupils;
+using DfE.GIAP.Core.MyPupils.Application.Extensions;
+using DfE.GIAP.Core.MyPupils.Application.Search.Options;
+using DfE.GIAP.Core.MyPupils.Application.Services.AggregatePupilsForMyPupils.Dto;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Core.User.Application;
+using DfE.GIAP.Core.User.Infrastructure.Repository.Dtos;
+using DfE.GIAP.SharedTests.TestDoubles;
+using Microsoft.Extensions.Options;
+
+namespace DfE.GIAP.Core.IntegrationTests.MyPupils.UseCases;
+
+[Collection(IntegrationTestCollectionMarker.Name)]
+public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegrationTest
+{
+#nullable disable
+    private MyPupilsTestContext _context;
+#nullable enable
+    public DeletePupilsFromMyPupilsUseCaseIntegrationTests(CosmosDbFixture cosmosDbFixture) : base(cosmosDbFixture)
+    {
+
+    }
+
+    private sealed record MyPupilsTestContext(SearchIndexFixture fixture, List<UniquePupilNumber> myPupilUpns, UserDto user);
+    protected async override Task OnInitializeAsync(IServiceCollection services)
+    {
+        services.AddMyPupilsDependencies();
+
+        // Initialise fixture and pupils, store in context
+        SearchIndexFixture mockSearchFixture = new(
+            ResolveTypeFromScopedContext<IOptions<SearchIndexOptions>>());
+
+        IEnumerable<AzureIndexEntity> npdSearchindexDtos = mockSearchFixture.StubNpdSearchIndex();
+        IEnumerable<AzureIndexEntity> pupilPremiumSearchIndexDtos = mockSearchFixture.StubPupilPremiumSearchIndex();
+
+        List<AzureIndexEntity> myPupils = npdSearchindexDtos.Concat(pupilPremiumSearchIndexDtos).ToList();
+        List<UniquePupilNumber> myPupilsUpns = myPupils.Select(t => t.UPN).ToUniquePupilNumbers().ToList();
+
+        UserId userId = UserIdTestDoubles.Default();
+        UserDto seededUserDto = UserDtoTestDoubles.WithPupils(userId, myPupilsUpns);
+        await Fixture.Database.WriteItemAsync(seededUserDto);
+        _context = new MyPupilsTestContext(mockSearchFixture, myPupilsUpns, seededUserDto);
+    }
+
+    protected override Task OnDisposeAsync()
+    {
+        _context?.fixture?.Dispose();
+        return Task.CompletedTask;
+    }
+
+
+    [Fact]
+    public async Task DeletePupilsFromMyPupils_Throws_InvalidArgumentException_When_Any_PupilIdentifier_Is_Not_Part_Of_The_List()
+    {
+        // Arrange
+        IEnumerable<string> unknownPupilIdentifier = [UniquePupilNumberTestDoubles.Generate().Value];
+
+        // Act
+        DeletePupilsFromMyPupilsRequest request = new(
+            _context!.user.id,
+            DeletePupilUpns: unknownPupilIdentifier,
+            DeleteAll: false);
+
+        IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
+            ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.HandleRequestAsync(request));
+
+        IEnumerable<UserDto> users = await Fixture.Database.ReadManyAsync<UserDto>();
+        UserDto userDto = Assert.Single(users);
+        Assert.NotNull(userDto);
+        Assert.Equivalent(_context.user, userDto);
+    }
+
+    [Fact]
+    public async Task DeletePupilsFromMyPupils_Deletes_Item_When_PupilIdentifier_Is_Part_Of_The_List()
+    {
+        // Arrange
+        IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
+            ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
+
+        // Act
+        string deletePupilIdentifier = _context.myPupilUpns[0].Value;
+        DeletePupilsFromMyPupilsRequest request = new(
+            _context.user.id,
+            DeletePupilUpns: [deletePupilIdentifier],
+            DeleteAll: false);
+
+        await sut.HandleRequestAsync(request);
+
+        // Assert
+        IEnumerable<UserDto> users = await Fixture.Database.ReadManyAsync<UserDto>();
+        List<string> remainingUpnsAfterDelete =
+            _context.myPupilUpns
+                .Where((upn) => upn.Value != deletePupilIdentifier)
+                .Select(t => t.Value).ToList();
+
+        UserDto actualUserDTO = Assert.Single(users);
+        Assert.NotNull(actualUserDTO);
+        Assert.Equivalent(remainingUpnsAfterDelete, actualUserDTO.MyPupils.Pupils.Select(t => t.UPN));
+    }
+
+    [Fact]
+    public async Task DeletePupilsFromMyPupils_Deletes_Multiples_When_PupilIdentifier_Is_Part_Of_The_List()
+    {
+        // Arrange
+        IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
+            ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
+
+        // Act
+        List<string> deleteMultiplePupilIdentifiers =
+        [
+            _context.myPupilUpns[0].Value,
+            _context.myPupilUpns[4].Value,
+            _context.myPupilUpns[_context.myPupilUpns.Count-1].Value
+        ];
+
+        DeletePupilsFromMyPupilsRequest request = new(
+            _context.user.id,
+            DeletePupilUpns: deleteMultiplePupilIdentifiers,
+            DeleteAll: false);
+
+        await sut.HandleRequestAsync(request);
+
+        // Assert
+        IEnumerable<UserDto> users = await Fixture.Database.ReadManyAsync<UserDto>();
+
+        List<string> remainingUpnsAfterDelete =
+            _context.myPupilUpns
+                .Where((upn) => !deleteMultiplePupilIdentifiers.Contains(upn.Value))
+                .Select(t => t.Value).ToList();
+
+        UserDto actualUserDto = Assert.Single(users);
+        Assert.NotNull(actualUserDto);
+        Assert.NotEmpty(remainingUpnsAfterDelete);
+        Assert.Equivalent(remainingUpnsAfterDelete, actualUserDto.MyPupils.Pupils.Select(t => t.UPN));
+    }
+
+    [Fact]
+    public async Task DeletePupilsFromMyPupils_Deletes_All_Items_When_DeleteAll_Is_True()
+    {
+        // Arrange
+        IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
+            ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
+
+        // Act
+        bool deleteAllPupils = true;
+        DeletePupilsFromMyPupilsRequest request = new(
+            _context.user.id,
+            DeletePupilUpns: [Guid.NewGuid().ToString()], // should be ignored if DeleteAll is enabled
+            DeleteAll: deleteAllPupils);
+
+        await sut.HandleRequestAsync(request);
+
+        // Assert
+        IEnumerable<UserDto> users = await Fixture.Database.ReadManyAsync<UserDto>();
+        UserDto userDto = Assert.Single(users);
+        Assert.NotNull(userDto);
+        Assert.Equal(_context.user.id, userDto.id);
+        Assert.Empty(userDto.MyPupils.Pupils);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
@@ -51,31 +51,6 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
         return Task.CompletedTask;
     }
 
-
-    [Fact]
-    public async Task DeletePupilsFromMyPupils_Throws_InvalidArgumentException_When_Any_PupilIdentifier_Is_Not_Part_Of_The_List()
-    {
-        // Arrange
-        IEnumerable<string> unknownPupilIdentifier = [UniquePupilNumberTestDoubles.Generate().Value];
-
-        // Act
-        DeletePupilsFromMyPupilsRequest request = new(
-            _context!.user.id,
-            DeletePupilUpns: unknownPupilIdentifier,
-            DeleteAll: false);
-
-        IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
-            ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
-
-        // Assert
-        await Assert.ThrowsAsync<ArgumentException>(() => sut.HandleRequestAsync(request));
-
-        IEnumerable<UserDto> users = await Fixture.Database.ReadManyAsync<UserDto>();
-        UserDto userDto = Assert.Single(users);
-        Assert.NotNull(userDto);
-        Assert.Equivalent(_context.user, userDto);
-    }
-
     [Fact]
     public async Task DeletePupilsFromMyPupils_Deletes_Item_When_PupilIdentifier_Is_Part_Of_The_List()
     {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/MyPupils/UseCases/DeletePupilsFromMyPupilsUseCaseIntegrationTests.cs
@@ -58,13 +58,13 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
         IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
             ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
 
-        // Act
         string deletePupilIdentifier = _context.myPupilUpns[0].Value;
         DeletePupilsFromMyPupilsRequest request = new(
             _context.user.id,
             DeletePupilUpns: [deletePupilIdentifier],
             DeleteAll: false);
 
+        // Act
         await sut.HandleRequestAsync(request);
 
         // Assert
@@ -86,7 +86,6 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
         IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
             ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
 
-        // Act
         List<string> deleteMultiplePupilIdentifiers =
         [
             _context.myPupilUpns[0].Value,
@@ -99,6 +98,7 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
             DeletePupilUpns: deleteMultiplePupilIdentifiers,
             DeleteAll: false);
 
+        // Act
         await sut.HandleRequestAsync(request);
 
         // Assert
@@ -122,7 +122,6 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
         IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
             ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
 
-        // Act
         List<string> deleteMultiplePupilIdentifiers =
         [
             _context.myPupilUpns[0].Value,
@@ -135,6 +134,7 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
             DeletePupilUpns: deleteMultiplePupilIdentifiers,
             DeleteAll: false);
 
+        // Act
         await sut.HandleRequestAsync(request);
 
         // Assert
@@ -158,13 +158,13 @@ public sealed class DeletePupilsFromMyPupilsUseCaseIntegrationTests : BaseIntegr
         IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest> sut =
             ResolveTypeFromScopedContext<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>();
 
-        // Act
         bool deleteAllPupils = true;
         DeletePupilsFromMyPupilsRequest request = new(
             _context.user.id,
             DeletePupilUpns: [Guid.NewGuid().ToString()], // should be ignored if DeleteAll is enabled
             DeleteAll: deleteAllPupils);
 
+        // Act
         await sut.HandleRequestAsync(request);
 
         // Assert

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsUseCaseTests.cs
@@ -1,0 +1,122 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Core.UnitTests.TestDoubles;
+using DfE.GIAP.Core.User.Application.Repository;
+using DfE.GIAP.SharedTests.TestDoubles;
+
+namespace DfE.GIAP.Core.UnitTests.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
+
+public sealed class DeletePupilsFromMyPupilsUseCaseTests
+{
+    [Fact]
+    public async Task HandleRequestAsync_WhenDeleteAllIsTrue_SavesEmptyList()
+    {
+        // Arrange
+        User.Application.User user = UserTestDoubles.Default();
+        Mock<IUserReadOnlyRepository> mockReadRepository = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user);
+        Mock<IUserWriteRepository> writeRepoDouble = UserWriteRepositoryTestDoubles.Default();
+        DeletePupilsFromMyPupilsUseCase useCase = new(mockReadRepository.Object, writeRepoDouble.Object);
+
+        DeletePupilsFromMyPupilsRequest request = new(
+            UserId: user.UserId.Value,
+            DeleteAll: true,
+            DeletePupilUpns: ["UPN1", "UPN2"]); // these should be ignored when deleteAll toggled
+
+        // Act
+        await useCase.HandleRequestAsync(request);
+
+        // Assert
+        writeRepoDouble.Verify(repo =>
+            repo.SaveMyPupilsAsync(
+                user.UserId,
+                It.Is<IEnumerable<UniquePupilNumber>>(list => !list.Any())),
+            Times.Once);
+
+        mockReadRepository.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task HandleRequestAsync_WhenSomeUpnsAreValid_SavesUpnsThatAreNotDeleted()
+    {
+        // Arrange
+
+        List<UniquePupilNumber> upns = UniquePupilNumberTestDoubles.Generate(count: 3);
+        User.Application.User user = UserTestDoubles.WithUpns(upns);
+
+        Mock<IUserReadOnlyRepository> mockReadRepository = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user);
+        mockReadRepository
+            .Setup((repo) =>
+                repo.GetUserByIdAsync(
+                    user.UserId,
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        Mock<IUserWriteRepository> mockWriteRepository = UserWriteRepositoryTestDoubles.Default();
+        DeletePupilsFromMyPupilsUseCase useCase = new(mockReadRepository.Object, mockWriteRepository.Object);
+        
+        IEnumerable<string> deletePupilUpnIdentifiers = user.UniquePupilNumbers.Take(1).Select(t => t.Value);
+
+        DeletePupilsFromMyPupilsRequest request = new(
+            UserId: user.UserId.Value,
+            DeleteAll: false,
+            DeletePupilUpns: deletePupilUpnIdentifiers);
+
+        // Act
+        await useCase.HandleRequestAsync(request);
+
+        // Assert
+        mockReadRepository.Verify(
+            (repo) => repo.GetUserByIdAsync(
+                user.UserId,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        IEnumerable<UniquePupilNumber> expectedListAfterDelete = user.UniquePupilNumbers.Where(t => !deletePupilUpnIdentifiers.Contains(t.Value));
+
+        mockWriteRepository.Verify(repo =>
+            repo.SaveMyPupilsAsync(
+                user.UserId,
+                It.Is<IEnumerable<UniquePupilNumber>>(list => list.SequenceEqual(expectedListAfterDelete))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleRequestAsync_WhenNoUpnsMatch_ThrowsArgumentException()
+    {
+        // Arrange
+        List<UniquePupilNumber> upns = UniquePupilNumberTestDoubles.Generate(count: 3);
+        User.Application.User user = UserTestDoubles.WithUpns(upns);
+
+        Mock<IUserReadOnlyRepository> mockReadRepository = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user);
+        mockReadRepository
+            .Setup((repo) =>
+                repo.GetUserByIdAsync(
+                    user.UserId,
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        Mock<IUserWriteRepository> mockWriteRepository = UserWriteRepositoryTestDoubles.Default();
+        DeletePupilsFromMyPupilsUseCase useCase = new(mockReadRepository.Object, mockWriteRepository.Object);
+
+        DeletePupilsFromMyPupilsRequest request = new(
+            UserId: user.UserId.Value,
+            DeleteAll: false,
+            DeletePupilUpns: ["UNKNOWN_UPN"]);
+
+        // Act 
+        await Assert.ThrowsAsync<ArgumentException>(() => useCase.HandleRequestAsync(request));
+
+        // Assert
+        mockReadRepository.Verify(
+            (repo) => repo.GetUserByIdAsync(
+                user.UserId,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        mockWriteRepository.Verify(
+            (repo) => repo.SaveMyPupilsAsync(
+                user.UserId,
+                It.IsAny<IEnumerable<UniquePupilNumber>>()),
+            Times.Never);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/DeletePupilsFromMyPupils/DeletePupilsFromMyPupilsUseCaseTests.cs
@@ -53,7 +53,7 @@ public sealed class DeletePupilsFromMyPupilsUseCaseTests
 
         Mock<IUserWriteRepository> mockWriteRepository = UserWriteRepositoryTestDoubles.Default();
         DeletePupilsFromMyPupilsUseCase useCase = new(mockReadRepository.Object, mockWriteRepository.Object);
-        
+
         IEnumerable<string> deletePupilUpnIdentifiers = user.UniquePupilNumbers.Take(1).Select(t => t.Value);
 
         DeletePupilsFromMyPupilsRequest request = new(

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/Application/UseCases/GetMyPupils/GetMyPupilsUseCaseTests.cs
@@ -8,7 +8,6 @@ using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
 using DfE.GIAP.Core.SharedTests.TestDoubles;
 using DfE.GIAP.Core.UnitTests.MyPupils.TestDoubles;
 using DfE.GIAP.Core.UnitTests.TestDoubles;
-using DfE.GIAP.Core.User.Application;
 using DfE.GIAP.Core.User.Application.Repository;
 using DfE.GIAP.SharedTests.TestDoubles;
 
@@ -19,10 +18,8 @@ public sealed class GetMyPupilsUseCaseTests
     public async Task HandleRequestAsync_ReturnsMappedPupils()
     {
         // Arrange
-
         User.Application.User user = UserTestDoubles.Default();
-
-        Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user, user.UserId);
+        Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user);
 
         List<Pupil> pupils =
             user.UniquePupilNumbers
@@ -64,17 +61,15 @@ public sealed class GetMyPupilsUseCaseTests
     public async Task HandleRequestAsync_WithEmptyPupilList_ReturnsEmptyResponse()
     {
         // Arrange
-        UserId userId = UserIdTestDoubles.Default();
-
         User.Application.User user = UserTestDoubles.WithEmptyUpns();
 
-        Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user, userId);
+        Mock<IUserReadOnlyRepository> userRepoMock = UserReadOnlyRepositoryTestDoubles.MockForGetUserById(user);
 
         Mock<IAggregatePupilsForMyPupilsApplicationService> mockAggregateService = AggregatePupilsForMyPupilsServiceTestDoubles.Default();
 
         Mock<IMapper<Pupil, PupilDto>> mockMapper = MapperTestDoubles.Default<Pupil, PupilDto>();
 
-        GetMyPupilsRequest request = new(userId.Value);
+        GetMyPupilsRequest request = new(user.UserId.Value);
 
         // Act
         GetMyPupilsUseCase sut = new(
@@ -89,7 +84,9 @@ public sealed class GetMyPupilsUseCaseTests
         Assert.Empty(result.Pupils);
 
         userRepoMock.Verify(repo =>
-            repo.GetUserByIdAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+            repo.GetUserByIdAsync(
+                user.UserId,
+                It.IsAny<CancellationToken>()), Times.Once);
 
         mockAggregateService.Verify(
             t => t.GetPupilsAsync(Enumerable.Empty<UniquePupilNumber>(), It.IsAny<MyPupilsQueryOptions>()), Times.Never);

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/CompositionRootTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/MyPupils/CompositionRootTests.cs
@@ -6,6 +6,7 @@ using DfE.GIAP.Core.MyPupils.Application.Search.Options;
 using DfE.GIAP.Core.MyPupils.Application.Search.Provider;
 using DfE.GIAP.Core.MyPupils.Application.Services.AggregatePupilsForMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.Services.AggregatePupilsForMyPupils.Mapper;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.DeletePupilsFromMyPupils;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Request;
 using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
 using DfE.GIAP.Core.MyPupils.Domain.Entities;
@@ -44,6 +45,8 @@ public sealed class CompositionRootTests
         Assert.NotNull(provider);
 
         Assert.NotNull(provider.GetService<IUseCase<GetMyPupilsRequest, GetMyPupilsResponse>>());
+        Assert.NotNull(provider.GetService<IUseCaseRequestOnly<DeletePupilsFromMyPupilsRequest>>());
+
         Assert.NotNull(provider.GetService<IAggregatePupilsForMyPupilsApplicationService>());
         Assert.NotNull(provider.GetService<IMapper<DecoratedSearchIndexDto, Pupil>>());
         Assert.NotNull(provider.GetService<IMapper<Pupil, PupilDto>>());

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/UserReadOnlyRepositoryTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/UserReadOnlyRepositoryTestDoubles.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DfE.GIAP.Core.User.Application;
+﻿using DfE.GIAP.Core.User.Application;
 using DfE.GIAP.Core.User.Application.Repository;
 
 namespace DfE.GIAP.Core.UnitTests.TestDoubles;
@@ -11,14 +6,12 @@ internal static class UserReadOnlyRepositoryTestDoubles
 {
     internal static Mock<IUserReadOnlyRepository> Default() => new();
 
-    internal static Mock<IUserReadOnlyRepository> MockForGetUserById(User.Application.User stub, UserId? userId = null)
+    internal static Mock<IUserReadOnlyRepository> MockForGetUserById(User.Application.User stub)
     {
         Mock<IUserReadOnlyRepository> repoMock = Default();
 
-        UserId matchUserId = userId is null ? It.IsAny<UserId>() : userId;
-
         repoMock.Setup(t => t.GetUserByIdAsync(
-                matchUserId,
+                stub.UserId,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(stub)
             .Verifiable();

--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/UserWriteRepositoryTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.UnitTests/TestDoubles/UserWriteRepositoryTestDoubles.cs
@@ -1,0 +1,7 @@
+﻿using DfE.GIAP.Core.User.Application.Repository;
+
+namespace DfE.GIAP.Core.UnitTests.TestDoubles;
+internal static class UserWriteRepositoryTestDoubles
+{
+    internal static Mock<IUserWriteRepository> Default() => new();
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UserDtoTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UserDtoTestDoubles.cs
@@ -1,6 +1,5 @@
 ﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
 using DfE.GIAP.Core.User.Application;
-using DfE.GIAP.Core.User.Infrastructure.Repository;
 using DfE.GIAP.Core.User.Infrastructure.Repository.Dtos;
 
 namespace DfE.GIAP.SharedTests.TestDoubles;

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UserTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UserTestDoubles.cs
@@ -12,10 +12,12 @@ public static class UserTestDoubles
         return user;
     }
 
-    public static User WithEmptyUpns()
+    public static User WithEmptyUpns() => WithUpns([]);
+
+    public static User WithUpns(IEnumerable<UniquePupilNumber> upns)
     {
         UserId userId = UserIdTestDoubles.Default();
-        User user = new(userId, []);
+        User user = new(userId, upns);
         return user;
     }
 }


### PR DESCRIPTION
## 📌 Summary

Continues from the introduction of user-write-repository in #212. The DeleteMyPupils UseCase uses to persist a deletion of 1 or more, or all pupils from MyPupils.

## 🔍 Related Issue(s)

#148 

## 🧪 Changes Made

- [x] feat – New feature

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
