### PR TITLE
chore: Bump test packages minors for wiremock and vs-xunit-runner

### DIFF
--- a/DfE.GIAP.All/tests/Directory.Packages.props
+++ b/DfE.GIAP.All/tests/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageVersion Include="Fare" Version="2.2.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="WireMock.Net" Version="1.8.17" />
+    <PackageVersion Include="WireMock.Net" Version="1.8.18" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>


### PR DESCRIPTION
## 📌 Summary

from #214 split off test package upgrades

## 🔍 Related Issue(s)

## 🧪 Changes Made

- [x] chore – Maintenance tasks (e.g., build, config, dependencies)

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
