### PR TITLE
chore: dotnet tool bumps major 5.x for reportgen, minor 10.x for sonarcloud scanner

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "4.5.8",
+      "version": "5.4.11",
       "commands": [
         "reportgenerator"
       ],
       "rollForward": false
     },
     "dotnet-sonarscanner": {
-      "version": "10.2.0",
+      "version": "10.3.0",
       "commands": [
         "dotnet-sonarscanner"
       ],


### PR DESCRIPTION
## 📌 Summary

bump some tool versions from #214 

## 🧪 Changes Made

- [x] chore – Maintenance tasks (e.g., build, config, dependencies)

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
