### PR TITLE
feat: PupilDtoPresentationHandler and Order implementation

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Extensions/SortDirectionExtensions.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Extensions/SortDirectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Extensions;
+
+public static class SortDirectionExtensions
+{
+    public static string ToFormSortDirection(this SortDirection sortDirection)
+    {
+        return sortDirection switch
+        {
+            SortDirection.Ascending => "asc",
+            SortDirection.Descending => "desc",
+            _ => string.Empty
+        };
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/IPupilDtoPresentationHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/IPupilDtoPresentationHandler.cs
@@ -1,0 +1,9 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers;
+
+public interface IPupilDtoPresentationHandler
+{
+    IEnumerable<PupilDto> Handle(IEnumerable<PupilDto> pupils, PupilsPresentationOptions options);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/IPupilPresentationOptionsProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/IPupilPresentationOptionsProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+public interface IPupilsPresentationOptionsProvider
+{
+    PupilsPresentationOptions GetOptions();
+    void SetOptions(PupilsPresentationOptions options);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/PupilPresentationOptions.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/PupilPresentationOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+public record PupilsPresentationOptions(
+    int Page,
+    string SortBy,
+    SortDirection SortDirection);

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/PupilPresentationOptionsProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/PupilPresentationOptionsProvider.cs
@@ -1,0 +1,32 @@
+﻿using DfE.GIAP.Web.Providers.Session;
+
+namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+public sealed class PupilsPresentationOptionsProvider : IPupilsPresentationOptionsProvider
+{
+    private readonly ISessionProvider _sessionProvider;
+    public PupilsPresentationOptionsProvider(ISessionProvider sessionProvider)
+    {
+        ArgumentNullException.ThrowIfNull(sessionProvider);
+        _sessionProvider = sessionProvider;
+    }
+
+    public PupilsPresentationOptions GetOptions()
+    {
+        PupilsPresentationOptions options =
+            _sessionProvider.ContainsSessionKey(nameof(PupilsPresentationOptions)) ?
+                _sessionProvider.GetSessionValueOrDefault<PupilsPresentationOptions>(nameof(PupilsPresentationOptions)) :
+                    new(
+                        Page: 1,
+                        SortBy: string.Empty,
+                        SortDirection: SortDirection.Descending);
+
+        return options;
+    }
+
+    public void SetOptions(PupilsPresentationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _sessionProvider.SetSessionValue(nameof(PupilsPresentationOptions), options);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/SortDirection.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/Options/SortDirection.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+public enum SortDirection
+{
+    Ascending,
+    Descending
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/OrderHandler/OrderPupilDtosPresentationHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilDtoPresentationHandlers/OrderHandler/OrderPupilDtosPresentationHandler.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq.Expressions;
+using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+
+namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.OrderHandler;
+public sealed class OrderPupilDtosPresentationHandler : IPupilDtoPresentationHandler
+{
+    private static readonly Dictionary<string, Expression<Func<PupilDto, IComparable>>> s_sortKeyToExpression = new()
+        {
+            { "forename", (t) => t.Forename },
+            { "surname", (t) => t.Surname },
+            { "dob", (t) => t.ParseDateOfBirth() },
+            { "sex", (t) => t.Sex }
+        };
+
+    public IEnumerable<PupilDto> Handle(
+        IEnumerable<PupilDto> pupils,
+        PupilsPresentationOptions options)
+    {
+        if (string.IsNullOrEmpty(options.SortBy))
+        {
+            return pupils;
+        }
+
+        if (!s_sortKeyToExpression.TryGetValue(options.SortBy.ToLowerInvariant(), out Expression<Func<PupilDto, IComparable>> expression)
+                || expression is null)
+        {
+            throw new ArgumentException($"Unable to find sortable expression for {options.SortBy}");
+        }
+
+        return options.SortDirection == SortDirection.Ascending ?
+                    pupils.AsQueryable().OrderBy(expression) :
+                    pupils.AsQueryable().OrderByDescending(expression);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/OrderPupilDtosPresentationHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/OrderPupilDtosPresentationHandlerTests.cs
@@ -1,0 +1,146 @@
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils.Response;
+using DfE.GIAP.SharedTests.TestDoubles;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.OrderHandler;
+using DfE.GIAP.Web.Tests.Controllers.MyPupilList.TestDoubles;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Controllers.MyPupilList;
+
+public sealed class OrderPupilDtosPresentationHandlerTests
+{
+    [Fact]
+    public void Handle_SortBy_Empty_Returns_Unsorted_Pupils()
+    {
+        // Arrange
+        PupilsPresentationOptions options = PupilPresentationOptionsTestDoubles.Create(sortKey: string.Empty);
+
+        List<PupilDto> pupils = PupilDtoTestDoubles.Generate(count: 10);
+
+        OrderPupilDtosPresentationHandler sut = new();
+
+        // Act
+        IEnumerable<PupilDto> response = sut.Handle(pupils, options);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(pupils, response);
+    }
+
+    [Fact]
+    public void Handle_SortBy_UnknownKey_Throws_ArgumentException()
+    {
+        // Arrange
+        PupilsPresentationOptions options = PupilPresentationOptionsTestDoubles.Create(sortKey: "unknown-sortByKey");
+
+        OrderPupilDtosPresentationHandler sut = new();
+
+        // Act Assert
+        Action act = () => sut.Handle(It.IsAny<IEnumerable<PupilDto>>(), options);
+        Assert.Throws<ArgumentException>(act);
+    }
+
+    [Theory]
+    [InlineData("forename", SortDirection.Ascending)]
+    [InlineData("forename", SortDirection.Descending)]
+    [InlineData("FORENAME", SortDirection.Ascending)]
+    [InlineData("foRENamE", SortDirection.Descending)]
+    public void Handle_SortBy_Forename_Returns_SortedPupils_By_Forename(string sortKey, SortDirection sortDirection)
+    {
+        // Arrange
+        PupilsPresentationOptions options = PupilPresentationOptionsTestDoubles.Create(sortKey, sortDirection);
+
+        IEnumerable<PupilDto> pupils = PupilDtoTestDoubles.Generate(count: 20);
+
+        OrderPupilDtosPresentationHandler sut = new();
+
+        // Act
+        IEnumerable<PupilDto> response = sut.Handle(pupils, options);
+
+        // Assert
+        IEnumerable<PupilDto> expected =
+            sortDirection == SortDirection.Ascending ?
+                pupils.OrderBy(t => t.Forename) :
+                pupils.OrderByDescending(t => t.Forename);
+
+        Assert.Equal(expected, response);
+    }
+
+    [Theory]
+    [InlineData("surname", SortDirection.Ascending)]
+    [InlineData("surname", SortDirection.Descending)]
+    [InlineData("SURNAME", SortDirection.Ascending)]
+    [InlineData("suRnAme", SortDirection.Descending)]
+    public void Handle_SortBy_Surname_Returns_SortedPupils_By_Surname(string sortKey, SortDirection sortDirection)
+    {
+        // Arrange
+        PupilsPresentationOptions options = PupilPresentationOptionsTestDoubles.Create(sortKey, sortDirection);
+
+        IEnumerable<PupilDto> pupils = PupilDtoTestDoubles.Generate(count: 20);
+
+        OrderPupilDtosPresentationHandler sut = new();
+
+        // Act
+        IEnumerable<PupilDto> response = sut.Handle(pupils, options);
+        IEnumerable<PupilDto> expected =
+            sortDirection == SortDirection.Ascending ?
+                pupils.OrderBy(t => t.Surname) :
+                pupils.OrderByDescending(t => t.Surname);
+
+        // Assert
+        Assert.Equal(expected, response);
+    }
+
+    [Theory]
+    [InlineData("dob", SortDirection.Ascending)]
+    [InlineData("dob", SortDirection.Descending)]
+    [InlineData("DOB", SortDirection.Ascending)]
+    [InlineData("dOB", SortDirection.Descending)]
+    public void Handle_SortBy_DateOfBirth_Returns_SortedPupils_By_DateOfBirth(string sortKey, SortDirection sortDirection)
+    {
+        // Arrange
+        PupilsPresentationOptions options = PupilPresentationOptionsTestDoubles.Create(sortKey, sortDirection);
+
+        IEnumerable<PupilDto> pupils = PupilDtoTestDoubles.Generate(count: 20);
+
+        OrderPupilDtosPresentationHandler sut = new();
+
+        // Act
+        IEnumerable<PupilDto> response = sut.Handle(pupils, options);
+
+        // Assert
+        IEnumerable<PupilDto> expected =
+            sortDirection == SortDirection.Ascending ?
+                pupils.OrderBy(t => t.ParseDateOfBirth()) :
+                pupils.OrderByDescending(t => t.ParseDateOfBirth());
+
+        Assert.Equal(expected, response);
+    }
+
+    [Theory]
+    [InlineData("sex", SortDirection.Ascending)]
+    [InlineData("sex", SortDirection.Descending)]
+    [InlineData("SEX", SortDirection.Ascending)]
+    [InlineData("seX", SortDirection.Descending)]
+    public void Handle_SortBy_Sex_Returns_SortedPupils_By_Sex(string sortKey, SortDirection sortDirection)
+    {
+        // Arrange
+        PupilsPresentationOptions options = PupilPresentationOptionsTestDoubles.Create(sortKey, sortDirection);
+
+        IEnumerable<PupilDto> pupils = PupilDtoTestDoubles.Generate(count: 20);
+
+        OrderPupilDtosPresentationHandler sut = new();
+
+        // Act
+        IEnumerable<PupilDto> response = sut.Handle(pupils, options);
+
+        // Assert
+        IEnumerable<PupilDto> expected =
+            sortDirection == SortDirection.Ascending ?
+                pupils.OrderBy(t => t.Sex) :
+                pupils.OrderByDescending(t => t.Sex);
+
+        Assert.Equal(expected, response);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/TestDoubles/PupilPresentationOptionsTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/TestDoubles/PupilPresentationOptionsTestDoubles.cs
@@ -1,0 +1,27 @@
+﻿using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilDtoPresentationHandlers.Options;
+using Moq;
+
+namespace DfE.GIAP.Web.Tests.Controllers.MyPupilList.TestDoubles;
+public static class PupilPresentationOptionsTestDoubles
+{
+    public static PupilsPresentationOptions Create(string sortKey) => Create(sortKey, It.IsAny<SortDirection>());
+
+    public static PupilsPresentationOptions Create(string sortKey, SortDirection sortDirection)
+    {
+        return new(
+            Page: It.IsAny<int>(),
+            SortBy: sortKey,
+            SortDirection: sortDirection);
+    }
+
+    public static PupilsPresentationOptions Create(int page)
+    {
+        return new(
+            Page: page,
+            SortBy: It.IsAny<string>(),
+            SortDirection: It.IsAny<SortDirection>());
+    }
+
+    public static PupilsPresentationOptions CreateWithValidPage() => Create(page: 1);
+
+}


### PR DESCRIPTION
## 📌 Summary

Continuing from #220 this breaks off the `IPupilDtoPresentationHandler` abstraction which the PresentationService uses to apply handlers that have been registered - to apply ordering/paginating.

*note* the handler is not registered as this will be done when the `MyPupilsPresentationService` is registered.

## 🔍 Related Issue(s)

#148 

## 🧪 Changes Made

- [x] feat – New feature

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
