### PR TITLE
feat: MyPupils PupilSelectionState

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/UniquePupilNumberValidator.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/UniquePupilNumberValidator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+namespace DfE.GIAP.Core.Common.CrossCutting;
 public static class UniquePupilNumberValidator
 {
     // see GOV.UK spec

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Domain/ValueObjects/UniquePupilNumber.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Domain/ValueObjects/UniquePupilNumber.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Core.Common.Domain;
 
 namespace DfE.GIAP.Core.MyPupils.Domain.ValueObjects;

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/Provider/DataTransferObjects/PupilSelectionStateDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/Provider/DataTransferObjects/PupilSelectionStateDto.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider.DataTransferObjects;
+
+public sealed class PupilSelectionStateDto
+{
+    public Dictionary<string, bool> PupilUpnToSelectedMap { get; set; } = [];
+    public SelectAllPupilsState State { get; set; } = SelectAllPupilsState.NotSpecified;
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/Provider/IPupilSelectionStateProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/Provider/IPupilSelectionStateProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider;
+
+public interface IPupilSelectionStateProvider
+{
+    PupilsSelectionState GetState();
+    void UpdateState(PupilsSelectionState state);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/Provider/PupilSelectionStateProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/Provider/PupilSelectionStateProvider.cs
@@ -1,0 +1,34 @@
+﻿using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider.DataTransferObjects;
+using DfE.GIAP.Web.Providers.Session;
+
+namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider;
+
+public sealed class PupilSelectionStateProvider : IPupilSelectionStateProvider
+{
+    private static string SessionKey => nameof(PupilSelectionStateDto);
+    private readonly ISessionProvider _sessionProvider;
+
+    public PupilSelectionStateProvider(
+        ISessionProvider sessionProvider)
+    {
+        _sessionProvider = sessionProvider;
+    }
+
+    public PupilsSelectionState GetState()
+    {
+
+        PupilSelectionStateDto stateDtoFromSession =
+            _sessionProvider.ContainsSessionKey(SessionKey) ?
+                _sessionProvider.GetSessionValueOrDefault<PupilSelectionStateDto>(SessionKey) :
+                    new();
+
+        PupilsSelectionState pupilSelectionState = PupilsSelectionState.FromDto(stateDtoFromSession);
+        return pupilSelectionState;
+    }
+
+    public void UpdateState(PupilsSelectionState state)
+    {
+        PupilSelectionStateDto updatedStateAsDto = state.ToDto();
+        _sessionProvider.SetSessionValue(SessionKey, updatedStateAsDto);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/PupilsSelectionState.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/PupilsSelectionState.cs
@@ -1,4 +1,4 @@
-﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+﻿using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider.DataTransferObjects;
 
 namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState;

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/PupilsSelectionState.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/PupilsSelectionState.cs
@@ -1,0 +1,107 @@
+﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider.DataTransferObjects;
+
+namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState;
+
+public sealed class PupilsSelectionState
+{
+    private readonly Dictionary<string, bool> _pupilsToSelectedMap = [];
+    private SelectAllPupilsState _state = SelectAllPupilsState.NotSpecified;
+
+    public bool IsAllPupilsSelected => _state == SelectAllPupilsState.SelectAll;
+
+    public bool IsPupilSelected(string upn)
+    {
+        if (IsAllPupilsSelected)
+        {
+            return true;
+        }
+
+        if (_pupilsToSelectedMap.TryGetValue(upn, out bool selected))
+        {
+            return selected;
+        }
+
+        return false;
+    }
+
+    public IReadOnlyCollection<string> GetSelectedPupils()
+    {
+        return _pupilsToSelectedMap
+            .Where(t => t.Value)
+            .Select(t => t.Key)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    public void AddPupils(IEnumerable<string> upns) => UpdatePupilSelectionState(upns, isSelected: false);
+
+    public void SelectAllPupils()
+    {
+        _state = SelectAllPupilsState.SelectAll;
+
+        if (_pupilsToSelectedMap.Keys.Count == 0)
+        {
+            return;
+        }
+
+        UpdatePupilSelectionState(_pupilsToSelectedMap.Keys, isSelected: true);
+    }
+
+    public void DeselectAllPupils()
+    {
+        _state = SelectAllPupilsState.DeselectAll;
+
+        if (_pupilsToSelectedMap.Keys.Count == 0)
+        {
+            return;
+        }
+        UpdatePupilSelectionState(_pupilsToSelectedMap.Keys, isSelected: false);
+    }
+
+    public void UpdatePupilSelectionState(IEnumerable<string> upns, bool isSelected)
+    {
+        ArgumentNullException.ThrowIfNull(upns);
+
+        if (!upns.Any())
+        {
+            throw new ArgumentException("Upns is empty");
+        }
+
+        foreach (string upn in upns)
+        {
+            if (!UniquePupilNumberValidator.Validate(upn))
+            {
+                throw new ArgumentException("Invalid UPN requested");
+            }
+
+            _pupilsToSelectedMap[upn] = isSelected;
+        }
+    }
+
+    public void ResetState()
+    {
+        _pupilsToSelectedMap.Clear();
+        _state = SelectAllPupilsState.NotSpecified;
+    }
+
+    public PupilSelectionStateDto ToDto() => new()
+    {
+        PupilUpnToSelectedMap = new(_pupilsToSelectedMap),
+        State = _state
+    };
+
+    public static PupilsSelectionState FromDto(PupilSelectionStateDto dto)
+    {
+        PupilsSelectionState state = new()
+        {
+            _state = dto.State
+        };
+
+        foreach (KeyValuePair<string, bool> kvp in dto.PupilUpnToSelectedMap)
+        {
+            state._pupilsToSelectedMap[kvp.Key] = kvp.Value;
+        }
+        return state;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/SelectAllPupilsState.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/MyPupilList/Services/Presentation/PupilSelectionState/SelectAllPupilsState.cs
@@ -1,0 +1,8 @@
+﻿namespace DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState;
+
+public enum SelectAllPupilsState
+{
+    SelectAll,
+    DeselectAll,
+    NotSpecified
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Providers/Session/SessionProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Providers/Session/SessionProvider.cs
@@ -21,7 +21,12 @@ public class SessionProvider : ISessionProvider
         Session.SetString(key, value);
     }
 
-    public void SetSessionValue<T>(string key, T value) => SetSessionValue(key, JsonSerializer.Serialize(value));
+    public void SetSessionValue<T>(string key, T value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        string json = JsonSerializer.Serialize(value);
+        Session.SetString(key, json);
+    }
 
     public string? GetSessionValue(string key)
     {
@@ -37,7 +42,7 @@ public class SessionProvider : ISessionProvider
 
     public void RemoveSessionValue(string key)
     {
-        ArgumentNullException.ThrowIfNullOrEmpty(key);
+        ArgumentException.ThrowIfNullOrEmpty(key);
         Session.Remove(key);
     }
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UniquePupilNumberTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UniquePupilNumberTestDoubles.cs
@@ -27,4 +27,5 @@ public static class UniquePupilNumberTestDoubles
         return upns;
     }
 
+    public static List<string> GenerateAsValues(int count) => Generate(count).Select(t => t.Value).ToList();
 }

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UniquePupilNumberTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests/TestDoubles/UniquePupilNumberTestDoubles.cs
@@ -1,4 +1,5 @@
-﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
 using Fare;
 
 namespace DfE.GIAP.SharedTests.TestDoubles;

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/PupilsSelectionStateTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/PupilsSelectionStateTests.cs
@@ -1,0 +1,235 @@
+﻿using DfE.GIAP.SharedTests.TestDoubles;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState.Provider.DataTransferObjects;
+using DfE.GIAP.Web.Tests.Controllers.MyPupilList.TestDoubles;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Controllers.MyPupilList;
+public sealed class PupilSelectionStateTests
+{
+    [Fact]
+    public void Default_State_Is_Empty()
+    {
+        // Arrange Act
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+
+        // Assert
+        Assert.False(state.IsAllPupilsSelected);
+        Assert.Empty(state.GetSelectedPupils());
+    }
+
+    [Fact]
+    public void SelectAllPupils_Updates_State_WithEmptyPupils()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+
+        // Act
+        state.SelectAllPupils();
+
+        // Assert
+        Assert.True(state.IsAllPupilsSelected);
+        Assert.Empty(state.GetSelectedPupils());
+    }
+
+    [Fact]
+    public void SelectAllPupils_Updates_State_WithSomePupils()
+    {
+        // Arrange
+        List<string> upns = UniquePupilNumberTestDoubles.GenerateAsValues(count: 3);
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateWithPupilUniquePupilNumbers(upns);
+
+        // Act
+        state.SelectAllPupils();
+
+        // Assert
+        Assert.True(state.IsAllPupilsSelected);
+        Assert.Equivalent(upns, state.GetSelectedPupils());
+        Assert.All(upns, upn => Assert.True(state.IsPupilSelected(upn)));
+    }
+
+    [Fact]
+    public void UpdateSelectionState_SelectsAndDeselectsPupils()
+    {
+        // Arrange
+        List<string> upns = UniquePupilNumberTestDoubles.GenerateAsValues(count: 3);
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateWithPupilUniquePupilNumbers(upns);
+
+        // Act
+        state.UpdatePupilSelectionState([upns[0]], true);
+        state.UpdatePupilSelectionState([upns[1]], false);
+
+        // Assert
+        Assert.True(state.IsPupilSelected(upns[0]));
+        Assert.False(state.IsPupilSelected(upns[1]));
+        Assert.Contains(upns[0], state.GetSelectedPupils());
+        Assert.DoesNotContain(upns[1], state.GetSelectedPupils());
+    }
+
+    [Fact]
+    public void DeselectAllPupils_Clears_Selections()
+    {
+        // Arrange
+        List<string> upns = UniquePupilNumberTestDoubles.GenerateAsValues(count: 3);
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateWithPupilUniquePupilNumbers(upns);
+
+        // Act
+        state.SelectAllPupils();
+        state.DeselectAllPupils();
+
+        // Assert
+        Assert.False(state.IsAllPupilsSelected);
+        Assert.Empty(state.GetSelectedPupils());
+        Assert.All(upns, upn => Assert.False(state.IsPupilSelected(upn)));
+    }
+
+    [Fact]
+    public void ResetState_Clears_All_Data()
+    {
+        // Arrange
+        List<string> upns = UniquePupilNumberTestDoubles.GenerateAsValues(count: 2);
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateWithPupilUniquePupilNumbers(upns);
+        string selectedUpn = upns[0];
+        state.UpdatePupilSelectionState([selectedUpn], true);
+
+        // Act
+        state.ResetState();
+
+        // Assert
+        Assert.False(state.IsAllPupilsSelected);
+        Assert.Empty(state.GetSelectedPupils());
+        Assert.All(upns, upn => Assert.False(state.IsPupilSelected(upn)));
+    }
+
+    [Fact]
+    public void AddPupils_WithNullOrEmpty_Throws()
+    {
+        // Arrange Act
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(() => state.AddPupils(null));
+        Assert.Throws<ArgumentException>(() => state.AddPupils([]));
+    }
+
+    [Fact]
+    public void AddPupils_WithInvalidUpn_Throws()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+        List<string> invalidUpns = ["INVALID_UPN"];
+
+        // Act & Assert
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => state.AddPupils(invalidUpns));
+        Assert.Equal("Invalid UPN requested", ex.Message);
+    }
+
+
+    [Fact]
+    public void AddPupils_WithDuplicateUpns_DoesNotThrowOrDuplicate()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+        string upn = UniquePupilNumberTestDoubles.Generate().Value;
+        state.AddPupils([upn, upn]);
+
+        // Act
+        state.UpdatePupilSelectionState([upn], true);
+
+        // Assert
+        Assert.Single(state.GetSelectedPupils());
+        Assert.True(state.IsPupilSelected(upn));
+    }
+
+
+    [Fact]
+    public void UpdateSelectionState_OnUnknownUpn_AddsAndMarksSelected()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+        string upn = UniquePupilNumberTestDoubles.Generate().Value;
+
+        // Act
+        state.UpdatePupilSelectionState([upn], true);
+
+        // Assert
+        Assert.True(state.IsPupilSelected(upn));
+        Assert.Contains(upn, state.GetSelectedPupils());
+    }
+
+    [Fact]
+    public void UpdateSelectionState_OnUnknownUpn_AddsAndMarksDeselected()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+        string upn = UniquePupilNumberTestDoubles.Generate().Value;
+
+        // Act
+        state.UpdatePupilSelectionState([upn], false);
+
+
+        // Assert
+        Assert.False(state.IsPupilSelected(upn));
+        Assert.DoesNotContain(upn, state.GetSelectedPupils());
+    }
+
+    [Fact]
+    public void UpdateSelectionState_WithInvalidUpn_Throws()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+        List<string> invalidUpns = ["INVALID-1", "INVALID-2"];
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => state.UpdatePupilSelectionState(invalidUpns, It.IsAny<bool>()));
+    }
+
+    [Fact]
+    public void UpdateSelectionState_WithMixedValidAndInvalidUpns_Throws()
+    {
+        // Arrange
+        PupilsSelectionState state = PupilsSelectionStateTestDoubles.CreateEmpty();
+        string validUpn = UniquePupilNumberTestDoubles.Generate().Value;
+        List<string> mixedUpns = [validUpn, "INVALID_UPN"];
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => state.UpdatePupilSelectionState(mixedUpns, It.IsAny<bool>()));
+    }
+
+    [Fact]
+    public void ToDto_And_FromDto_Preserves_State()
+    {
+        // Arrange
+        List<string> upns = UniquePupilNumberTestDoubles.GenerateAsValues(count: 2);
+        PupilsSelectionState original = PupilsSelectionStateTestDoubles.CreateEmpty();
+        original.AddPupils(upns);
+        original.UpdatePupilSelectionState([upns[0]], true);
+        original.SelectAllPupils();
+
+        // Act
+        PupilSelectionStateDto dto = original.ToDto();
+        PupilsSelectionState restored = PupilsSelectionState.FromDto(dto);
+
+        // Assert
+        Assert.True(restored.IsAllPupilsSelected);
+        Assert.Equivalent(original.GetSelectedPupils(), restored.GetSelectedPupils());
+        Assert.All(upns, upn => Assert.True(restored.IsPupilSelected(upn)));
+    }
+
+    [Fact]
+    public void FromDto_WithEmptyMapAndUnspecifiedState_CreatesEmptyState()
+    {
+        // Arrange
+        PupilSelectionStateDto dto = new()
+        {
+            PupilUpnToSelectedMap = [],
+            State = SelectAllPupilsState.NotSpecified
+        };
+
+        PupilsSelectionState state = PupilsSelectionState.FromDto(dto);
+
+        Assert.False(state.IsAllPupilsSelected);
+        Assert.Empty(state.GetSelectedPupils());
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/TestDoubles/PupilsSelectionStateTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/MyPupilList/TestDoubles/PupilsSelectionStateTestDoubles.cs
@@ -1,0 +1,25 @@
+﻿using DfE.GIAP.SharedTests.TestDoubles;
+using DfE.GIAP.Web.Controllers.MyPupilList.Services.Presentation.PupilSelectionState;
+
+namespace DfE.GIAP.Web.Tests.Controllers.MyPupilList.TestDoubles;
+public static class PupilsSelectionStateTestDoubles
+{
+    public static PupilsSelectionState CreateEmpty()
+    {
+        return new PupilsSelectionState();
+    }
+
+    public static PupilsSelectionState CreateWithPupilUniquePupilNumbers(IEnumerable<string> upns, bool selected = false)
+    {
+        PupilsSelectionState state = new();
+        state.AddPupils(upns);
+        state.UpdatePupilSelectionState(upns, selected);
+        return state;
+    }
+
+    public static PupilsSelectionState CreateWithSelectedPupils(int count)
+    {
+        List<string> upns = UniquePupilNumberTestDoubles.Generate(count).Select(t => t.Value).ToList();
+        return CreateWithPupilUniquePupilNumbers(upns, selected: true);
+    }
+}


### PR DESCRIPTION
## 📌 Summary

Continuing from #249 this breaks off the logic that handles PupilSelectionState in #220 so that selection of pupils in the MyPupils view is stored across requests.

## 🔍 Related Issue(s)

#148 

## 🧪 Changes Made

- [x] feat – New feature

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
