### PR TITLE
Session abstraction for Commands, Queries, IAspNetCoreSessionProvider

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Command/ISessionCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Command/ISessionCommandHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace DfE.GIAP.Web.Session.Abstraction.Command;
 
-public interface ISessionCommandHandler<in TValue>
+public interface ISessionCommandHandler<in TValue> where TValue : class
 {
     void StoreInSession(TValue value);
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Command/ISessionCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Command/ISessionCommandHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.GIAP.Web.Session.Abstraction.Command;
+
+public interface ISessionCommandHandler<in TValue>
+{
+    void StoreInSession(TValue value);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/ISessionObjectKeyResolver.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/ISessionObjectKeyResolver.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Web.Session.Abstraction;
+
+public interface ISessionObjectKeyResolver
+{
+    string Resolve<TSessionObject>();
+    string Resolve(Type sessionObject);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/ISessionObjectSerializer.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/ISessionObjectSerializer.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.GIAP.Web.Session.Abstraction;
+
+public interface ISessionObjectSerializer<TSessionObject>
+{
+    string Serialize(TSessionObject sessionObject);
+    TSessionObject Deserialize(string input);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/ISessionQueryHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/ISessionQueryHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.GIAP.Web.Session.Abstraction.Query;
+
+public interface ISessionQueryHandler<TSessionObject>
+{
+    SessionQueryResponse<TSessionObject> GetSessionObject();
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/ISessionQueryHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/ISessionQueryHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace DfE.GIAP.Web.Session.Abstraction.Query;
 
-public interface ISessionQueryHandler<TSessionObject>
+public interface ISessionQueryHandler<TSessionObject> where TSessionObject : class
 {
     SessionQueryResponse<TSessionObject> GetSessionObject();
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/SessionQueryResponse.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/SessionQueryResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace DfE.GIAP.Web.Session.Abstraction.Query;
+
+public record SessionQueryResponse<TValue>
+{
+    private SessionQueryResponse(
+        TValue? result,
+        bool valueExists)
+    {
+        Value = result;
+        HasValue = valueExists;
+    }
+
+    public TValue? Value { get; init; }
+    public bool HasValue { get; init; }
+
+    public static SessionQueryResponse<TValue> NoValue() => new(default(TValue), valueExists: false);
+    public static SessionQueryResponse<TValue> Create(TValue value) => new(value, valueExists: true);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/CompositionRoot.cs
@@ -1,0 +1,26 @@
+﻿using DfE.GIAP.Web.Session.Abstraction.Command;
+using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Session.Abstraction;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Query;
+using DfE.GIAP.Web.Session.Infrastructure;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Command;
+using DfE.GIAP.Web.Session.Infrastructure.Serialization;
+
+namespace DfE.GIAP.Web.Session;
+
+public static class CompositionRoot
+{
+    public static IServiceCollection AddAspNetCoreSessionServices(this IServiceCollection services)
+    {
+        services.TryAddScoped<IAspNetCoreSessionProvider, AspNetCoreSessionProvider>();
+
+        services.TryAddScoped(typeof(ISessionQueryHandler<>), typeof(AspNetCoreSessionQueryHandler<>));
+        services.TryAddScoped(typeof(ISessionCommandHandler<>), typeof(AspNetCoreSessionCommandHandler<>));
+
+        services.TryAddSingleton<ISessionObjectKeyResolver, SessionObjectKeyResolver>();
+        services.TryAddSingleton(typeof(ISessionObjectSerializer<>), typeof(DefaultSessionObjectSerializer<>));
+        return services;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/AspNetCoreSessionProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/AspNetCoreSessionProvider.cs
@@ -1,0 +1,27 @@
+﻿namespace DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+
+public sealed class AspNetCoreSessionProvider : IAspNetCoreSessionProvider
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public AspNetCoreSessionProvider(IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public ISession GetSession()
+    {
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new InvalidOperationException("HttpContext is not available. Unable to retrieve session");
+        }
+
+        if (_httpContextAccessor.HttpContext.Session is null)
+        {
+            throw new InvalidOperationException("Session is not available. Make sure session middleware is properly configured.");
+        }
+
+        return _httpContextAccessor.HttpContext.Session;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Command/AspNetCoreSessionCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Command/AspNetCoreSessionCommandHandler.cs
@@ -3,7 +3,7 @@ using DfE.GIAP.Web.Session.Abstraction;
 
 namespace DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Command;
 
-public sealed class AspNetCoreSessionCommandHandler<TValue> : ISessionCommandHandler<TValue>
+public sealed class AspNetCoreSessionCommandHandler<TValue> : ISessionCommandHandler<TValue> where TValue : class
 {
     private readonly IAspNetCoreSessionProvider _sessionProvider;
     private readonly ISessionObjectKeyResolver _sessionKeyResolver;

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Command/AspNetCoreSessionCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Command/AspNetCoreSessionCommandHandler.cs
@@ -24,8 +24,6 @@ public sealed class AspNetCoreSessionCommandHandler<TValue> : ISessionCommandHan
         _sessionObjectSerializer = sessionObjectSerializer;
     }
 
-    private string SessionObjectAccessKey => _sessionKeyResolver.Resolve<TValue>();
-
     public void StoreInSession(TValue value)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -34,6 +32,6 @@ public sealed class AspNetCoreSessionCommandHandler<TValue> : ISessionCommandHan
 
         _sessionProvider
             .GetSession()
-            .SetString(SessionObjectAccessKey, json);
+            .SetString(key: _sessionKeyResolver.Resolve<TValue>(), json);
     }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Command/AspNetCoreSessionCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Command/AspNetCoreSessionCommandHandler.cs
@@ -1,0 +1,39 @@
+﻿using DfE.GIAP.Web.Session.Abstraction.Command;
+using DfE.GIAP.Web.Session.Abstraction;
+
+namespace DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Command;
+
+public sealed class AspNetCoreSessionCommandHandler<TValue> : ISessionCommandHandler<TValue>
+{
+    private readonly IAspNetCoreSessionProvider _sessionProvider;
+    private readonly ISessionObjectKeyResolver _sessionKeyResolver;
+    private readonly ISessionObjectSerializer<TValue> _sessionObjectSerializer;
+
+    public AspNetCoreSessionCommandHandler(
+        IAspNetCoreSessionProvider sessionProvider,
+        ISessionObjectKeyResolver sessionKeyResolver,
+        ISessionObjectSerializer<TValue> sessionObjectSerializer)
+    {
+        ArgumentNullException.ThrowIfNull(sessionProvider);
+        _sessionProvider = sessionProvider;
+
+        ArgumentNullException.ThrowIfNull(sessionKeyResolver);
+        _sessionKeyResolver = sessionKeyResolver;
+
+        ArgumentNullException.ThrowIfNull(sessionObjectSerializer);
+        _sessionObjectSerializer = sessionObjectSerializer;
+    }
+
+    private string SessionObjectAccessKey => _sessionKeyResolver.Resolve<TValue>();
+
+    public void StoreInSession(TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        string json = _sessionObjectSerializer.Serialize(value);
+
+        _sessionProvider
+            .GetSession()
+            .SetString(SessionObjectAccessKey, json);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/IAspNetCoreSessionProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/IAspNetCoreSessionProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+
+public interface IAspNetCoreSessionProvider
+{
+    ISession GetSession();
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
@@ -24,18 +24,18 @@ public sealed class AspNetCoreSessionQueryHandler<TSessionObject> : ISessionQuer
         _sessionObjectSerializer = sessionObjectSerializer;
     }
 
-    private string SessionObjectKey => _sessionKeyResolver.Resolve<TSessionObject>();
-
     public SessionQueryResponse<TSessionObject> GetSessionObject()
     {
         ISession session = _sessionProvider.GetSession();
 
-        if (string.IsNullOrWhiteSpace(SessionObjectKey) || !session.TryGetValue(SessionObjectKey, out byte[] _))
+        string sessionObjectAccessKey = _sessionKeyResolver.Resolve<TSessionObject>();
+
+        if (string.IsNullOrWhiteSpace(sessionObjectAccessKey) || !session.TryGetValue(sessionObjectAccessKey, out byte[] _))
         {
             return SessionQueryResponse<TSessionObject>.NoValue();
         }
 
-        string sessionValue = session.GetString(SessionObjectKey);
+        string sessionValue = session.GetString(sessionObjectAccessKey);
 
         TSessionObject outputValue = _sessionObjectSerializer.Deserialize(sessionValue)!;
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
@@ -1,0 +1,44 @@
+﻿using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Session.Abstraction;
+
+namespace DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Query;
+
+public sealed class AspNetCoreSessionQueryHandler<TSessionObject> : ISessionQueryHandler<TSessionObject>
+{
+    private readonly IAspNetCoreSessionProvider _sessionProvider;
+    private readonly ISessionObjectKeyResolver _sessionKeyResolver;
+    private readonly ISessionObjectSerializer<TSessionObject> _sessionObjectSerializer;
+
+    public AspNetCoreSessionQueryHandler(
+        IAspNetCoreSessionProvider sessionProvider,
+        ISessionObjectKeyResolver sessionKeyResolver,
+        ISessionObjectSerializer<TSessionObject> sessionObjectSerializer)
+    {
+        ArgumentNullException.ThrowIfNull(sessionProvider);
+        _sessionProvider = sessionProvider;
+
+        ArgumentNullException.ThrowIfNull(sessionKeyResolver);
+        _sessionKeyResolver = sessionKeyResolver;
+
+        ArgumentNullException.ThrowIfNull(sessionObjectSerializer);
+        _sessionObjectSerializer = sessionObjectSerializer;
+    }
+
+    private string SessionObjectKey => _sessionKeyResolver.Resolve<TSessionObject>();
+
+    public SessionQueryResponse<TSessionObject> GetSessionObject()
+    {
+        ISession session = _sessionProvider.GetSession();
+
+        if (string.IsNullOrWhiteSpace(SessionObjectKey) || !session.TryGetValue(SessionObjectKey, out byte[] _))
+        {
+            return SessionQueryResponse<TSessionObject>.NoValue();
+        }
+
+        string sessionValue = session.GetString(SessionObjectKey);
+
+        TSessionObject outputValue = _sessionObjectSerializer.Deserialize(sessionValue)!;
+
+        return SessionQueryResponse<TSessionObject>.Create(outputValue);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
@@ -3,7 +3,7 @@ using DfE.GIAP.Web.Session.Abstraction;
 
 namespace DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Query;
 
-public sealed class AspNetCoreSessionQueryHandler<TSessionObject> : ISessionQueryHandler<TSessionObject>
+public sealed class AspNetCoreSessionQueryHandler<TSessionObject> : ISessionQueryHandler<TSessionObject> where TSessionObject : class
 {
     private readonly IAspNetCoreSessionProvider _sessionProvider;
     private readonly ISessionObjectKeyResolver _sessionKeyResolver;

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/Serialization/DefaultSessionObjectSerializer.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/Serialization/DefaultSessionObjectSerializer.cs
@@ -1,0 +1,10 @@
+﻿using DfE.GIAP.Web.Session.Abstraction;
+using Newtonsoft.Json;
+
+namespace DfE.GIAP.Web.Session.Infrastructure.Serialization;
+
+public class DefaultSessionObjectSerializer<TSessionObject> : ISessionObjectSerializer<TSessionObject>
+{
+    public TSessionObject Deserialize(string input) => JsonConvert.DeserializeObject<TSessionObject>(input);
+    public string Serialize(TSessionObject sessionObject) => JsonConvert.SerializeObject(sessionObject);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/Serialization/MappedToDataTransferObjectSessionObjectSerializer.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/Serialization/MappedToDataTransferObjectSessionObjectSerializer.cs
@@ -1,0 +1,35 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Web.Session.Abstraction;
+using Newtonsoft.Json;
+
+namespace DfE.GIAP.Web.Session.Infrastructure.Serialization;
+
+public class MappedToDataTransferObjectSessionObjectSerializer<TSessionObject, TDataTransferObject> : ISessionObjectSerializer<TSessionObject>
+{
+    private readonly IMapper<TSessionObject, TDataTransferObject> _mapToDto;
+    private readonly IMapper<TDataTransferObject, TSessionObject> _mapFromDto;
+
+    public MappedToDataTransferObjectSessionObjectSerializer(
+        IMapper<TSessionObject, TDataTransferObject> toDtoMapper,
+        IMapper<TDataTransferObject, TSessionObject> fromDtoMapper)
+    {
+        ArgumentNullException.ThrowIfNull(toDtoMapper);
+        _mapToDto = toDtoMapper;
+
+        ArgumentNullException.ThrowIfNull(fromDtoMapper);
+        _mapFromDto = fromDtoMapper;
+    }
+
+    public string Serialize(TSessionObject sessionObject)
+    {
+        TDataTransferObject dataTransferObject = _mapToDto.Map(sessionObject);
+        return JsonConvert.SerializeObject(dataTransferObject);
+    }
+
+    public TSessionObject Deserialize(string input)
+    {
+        TDataTransferObject dataTransferObject = JsonConvert.DeserializeObject<TDataTransferObject>(input);
+        TSessionObject sessionObject = _mapFromDto.Map(dataTransferObject);
+        return sessionObject;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/SessionObjectKeyResolver.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/SessionObjectKeyResolver.cs
@@ -1,0 +1,9 @@
+﻿using DfE.GIAP.Web.Session.Abstraction;
+
+namespace DfE.GIAP.Web.Session.Infrastructure;
+
+public sealed class SessionObjectKeyResolver : ISessionObjectKeyResolver
+{
+    public string Resolve<TSessionObject>() => Resolve(typeof(TSessionObject));
+    public string Resolve(Type sessionObject) => sessionObject.FullName;
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionCommandHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionCommandHandlerTests.cs
@@ -1,0 +1,106 @@
+﻿using DfE.GIAP.Web.Session.Abstraction;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Command;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+public sealed class AspNetCoreSessionCommandHandlerTests
+{
+    [Fact]
+    public void Constructor_Throws_When_SessionProvider_Is_Null()
+    {
+        // Arrange
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        Mock<ISessionObjectSerializer<StubSessionObject>> sessionObjectSerializer = new();
+        Func<AspNetCoreSessionCommandHandler<StubSessionObject>> construct =
+            () => new AspNetCoreSessionCommandHandler<StubSessionObject>(null, keyResolver.Object, sessionObjectSerializer.Object);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_SessionKeyResolver_Is_Null()
+    {
+        // Arrange
+        Mock<IAspNetCoreSessionProvider> sessionProvider = new();
+        Mock<ISessionObjectSerializer<StubSessionObject>> sessionObjectSerializer = new();
+        Func<AspNetCoreSessionCommandHandler<StubSessionObject>> construct =
+            () => new AspNetCoreSessionCommandHandler<StubSessionObject>(sessionProvider.Object, null, sessionObjectSerializer.Object);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_Serializer_Is_Null()
+    {
+        // Arrange
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        Mock<IAspNetCoreSessionProvider> sessionProvider = new();
+        Func<AspNetCoreSessionCommandHandler<StubSessionObject>> construct =
+            () => new AspNetCoreSessionCommandHandler<StubSessionObject>(sessionProvider.Object, keyResolver.Object, null);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void StoreInSession_Throws_When_Value_Is_Null()
+    {
+        // Arrange
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        Mock<IAspNetCoreSessionProvider> sessionProvider = new();
+        Mock<ISessionObjectSerializer<StubSessionObject>> sessionObjectSerializer = new();
+
+        AspNetCoreSessionCommandHandler<StubSessionObject> sut = new(sessionProvider.Object, keyResolver.Object, sessionObjectSerializer.Object);
+
+        Action act = () => sut.StoreInSession(null!);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void StoreInSession_ResolvesKey_And_Stores_Serialized_Value()
+    {
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        keyResolver
+            .Setup(t => t.Resolve<StubSessionObject>())
+            .Returns(It.IsAny<string>())
+            .Verifiable();
+
+        Mock<ISession> sessionMock = new();
+        sessionMock
+            .Setup((session) => session.Set(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Verifiable();
+
+        Mock<IAspNetCoreSessionProvider> sessionProviderMock = new();
+        sessionProviderMock
+            .Setup(provider => provider.GetSession())
+            .Returns(sessionMock.Object)
+            .Verifiable();
+
+        const string stubSerialisedValue = "store_this";
+        Mock<ISessionObjectSerializer<StubSessionObject>> sessionObjectSerializer = new();
+        sessionObjectSerializer
+            .Setup(serializer => serializer.Serialize(It.IsAny<StubSessionObject>()))
+            .Returns(stubSerialisedValue)
+            .Verifiable();
+
+        AspNetCoreSessionCommandHandler<StubSessionObject> sut = new(sessionProviderMock.Object, keyResolver.Object, sessionObjectSerializer.Object);
+
+        StubSessionObject stubSessionObject = new();
+        sut.StoreInSession(stubSessionObject);
+
+        // Act Assert
+        sessionMock.Verify(t => t.Set(It.IsAny<string>(), It.IsAny<byte[]>()), Times.Once);
+        sessionProviderMock.Verify(t => t.GetSession(), Times.Once);
+        keyResolver.Verify(t => t.Resolve<StubSessionObject>(), Times.Once);
+        sessionObjectSerializer.Verify(t => t.Serialize(stubSessionObject), Times.Once);
+    }
+
+    public sealed class StubSessionObject { }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionProviderTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionProviderTests.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using DfE.GIAP.Web.Tests.TestDoubles.Http;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
@@ -20,8 +21,7 @@ public sealed class AspNetCoreSessionProviderTests
     public void GetSession_Throws_When_HttpContext_Is_Null()
     {
         // Arrange
-        Mock<IHttpContextAccessor> httpContextAccessorMock = new();
-        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(() => null);
+        Mock<IHttpContextAccessor> httpContextAccessorMock = IHttpContextAccessorTestDoubles.WithHttpContext(null);
 
         // Act
         AspNetCoreSessionProvider sut = new(httpContextAccessorMock.Object);
@@ -35,12 +35,8 @@ public sealed class AspNetCoreSessionProviderTests
     public void GetSession_Throws_When_Session_Is_Null()
     {
         // Arrange
-        Mock<IHttpContextAccessor> httpContextAccessorMock = new();
-        DefaultHttpContext httpContextStub = new()
-        {
-            Session = null!
-        };
-        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(httpContextStub);
+        HttpContext httpContextStub = HttpContextTestDoubles.WithSession(null!);
+        Mock<IHttpContextAccessor> httpContextAccessorMock = IHttpContextAccessorTestDoubles.WithHttpContext(httpContextStub);
 
         // Act
         AspNetCoreSessionProvider sut = new(httpContextAccessorMock.Object);
@@ -54,13 +50,10 @@ public sealed class AspNetCoreSessionProviderTests
     public void GetSession_Returns_Session()
     {
         // Arrange
-        Mock<IHttpContextAccessor> httpContextAccessorMock = new();
         Mock<ISession> sessionMock = new();
-        DefaultHttpContext httpContextStub = new()
-        {
-            Session = sessionMock.Object
-        };
-        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(httpContextStub);
+        HttpContext httpContextStub = HttpContextTestDoubles.WithSession(sessionMock.Object);
+        Mock<IHttpContextAccessor> httpContextAccessorMock = IHttpContextAccessorTestDoubles.WithHttpContext(httpContextStub);
+
 
         // Act
         AspNetCoreSessionProvider sut = new(httpContextAccessorMock.Object);

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionProviderTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionProviderTests.cs
@@ -1,0 +1,73 @@
+﻿using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+public sealed class AspNetCoreSessionProviderTests
+{
+    [Fact]
+    public void Constructor_Throws_When_HttpContextAccessor_Is_Null()
+    {
+        //Arrange
+        Func<AspNetCoreSessionProvider> construct = () => new(null);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void GetSession_Throws_When_HttpContext_Is_Null()
+    {
+        // Arrange
+        Mock<IHttpContextAccessor> httpContextAccessorMock = new();
+        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(() => null);
+
+        // Act
+        AspNetCoreSessionProvider sut = new(httpContextAccessorMock.Object);
+
+        // Assert
+        InvalidOperationException noContextException = Assert.Throws<InvalidOperationException>(() => sut.GetSession());
+        Assert.Contains("HttpContext", noContextException.Message);
+    }
+
+    [Fact]
+    public void GetSession_Throws_When_Session_Is_Null()
+    {
+        // Arrange
+        Mock<IHttpContextAccessor> httpContextAccessorMock = new();
+        DefaultHttpContext httpContextStub = new()
+        {
+            Session = null!
+        };
+        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(httpContextStub);
+
+        // Act
+        AspNetCoreSessionProvider sut = new(httpContextAccessorMock.Object);
+
+        // Assert
+        InvalidOperationException noContextException = Assert.Throws<InvalidOperationException>(() => sut.GetSession());
+        Assert.Contains("Session", noContextException.Message);
+    }
+
+    [Fact]
+    public void GetSession_Returns_Session()
+    {
+        // Arrange
+        Mock<IHttpContextAccessor> httpContextAccessorMock = new();
+        Mock<ISession> sessionMock = new();
+        DefaultHttpContext httpContextStub = new()
+        {
+            Session = sessionMock.Object
+        };
+        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(httpContextStub);
+
+        // Act
+        AspNetCoreSessionProvider sut = new(httpContextAccessorMock.Object);
+
+        // Assert
+        ISession session = sut.GetSession();
+        Assert.NotNull(session);
+        Assert.Same(sessionMock.Object, session);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionQueryHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionQueryHandlerTests.cs
@@ -54,20 +54,27 @@ public sealed class AspNetCoreSessionQueryHandlerTests
     {
         // Arrange
         const string stubSessionObjectKey = "key";
-        Mock<ISessionObjectKeyResolver> keyResolver = new();
-        keyResolver.Setup(t => t.Resolve<StubSessionObject>()).Returns(stubSessionObjectKey);
+        Mock<ISessionObjectKeyResolver> keyResolverMock = new();
+        keyResolverMock
+            .Setup(keyResolver => keyResolver.Resolve<StubSessionObject>())
+            .Returns(stubSessionObjectKey)
+            .Verifiable();
 
         Mock<ISession> sessionMock = new();
         sessionMock
             .Setup(s => s.TryGetValue(stubSessionObjectKey, out It.Ref<byte[]>.IsAny!))
-            .Returns(false);
+            .Returns(false)
+            .Verifiable();
 
         Mock<IAspNetCoreSessionProvider> sessionProviderMock = new();
-        sessionProviderMock.Setup(t => t.GetSession()).Returns(sessionMock.Object);
+        sessionProviderMock
+            .Setup(sessionProvider => sessionProvider.GetSession())
+            .Returns(sessionMock.Object)
+            .Verifiable();
 
         Mock<ISessionObjectSerializer<StubSessionObject>> serializer = new();
 
-        AspNetCoreSessionQueryHandler<StubSessionObject> sut = new(sessionProviderMock.Object, keyResolver.Object, serializer.Object);
+        AspNetCoreSessionQueryHandler<StubSessionObject> sut = new(sessionProviderMock.Object, keyResolverMock.Object, serializer.Object);
 
         // Act
         SessionQueryResponse<StubSessionObject> sessionQueryResponse = sut.GetSessionObject();
@@ -77,6 +84,7 @@ public sealed class AspNetCoreSessionQueryHandlerTests
         Assert.False(sessionQueryResponse.HasValue);
 
         sessionProviderMock.Verify(t => t.GetSession(), Times.Once);
+        keyResolverMock.Verify(t => t.Resolve<StubSessionObject>(), Times.Once);
     }
 
     [Fact]

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionQueryHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/AspNetCoreSessionQueryHandlerTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Text;
+using DfE.GIAP.Web.Session.Abstraction;
+using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore.Query;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+public sealed class AspNetCoreSessionQueryHandlerTests
+{
+    [Fact]
+    public void Constructor_Throws_When_SessionProvider_Is_Null()
+    {
+        // Arrange
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        Mock<ISessionObjectSerializer<StubSessionObject>> sessionObjectSerializer = new();
+        Func<AspNetCoreSessionQueryHandler<StubSessionObject>> construct =
+            () => new AspNetCoreSessionQueryHandler<StubSessionObject>(null, keyResolver.Object, sessionObjectSerializer.Object);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_SessionKeyResolver_Is_Null()
+    {
+        // Arrange
+        Mock<IAspNetCoreSessionProvider> sessionProvider = new();
+        Mock<ISessionObjectSerializer<StubSessionObject>> sessionObjectSerializer = new();
+        Func<AspNetCoreSessionQueryHandler<StubSessionObject>> construct =
+            () => new AspNetCoreSessionQueryHandler<StubSessionObject>(sessionProvider.Object, null, sessionObjectSerializer.Object);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_Serializer_Is_Null()
+    {
+        // Arrange
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        Mock<IAspNetCoreSessionProvider> sessionProvider = new();
+        Func<AspNetCoreSessionQueryHandler<StubSessionObject>> construct =
+            () => new AspNetCoreSessionQueryHandler<StubSessionObject>(sessionProvider.Object, keyResolver.Object, null);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Session_DoesNotContain_Key_Returns_Default_And_ValueDoesNotExist()
+    {
+        // Arrange
+        const string stubSessionObjectKey = "key";
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        keyResolver.Setup(t => t.Resolve<StubSessionObject>()).Returns(stubSessionObjectKey);
+
+        Mock<ISession> sessionMock = new();
+        sessionMock
+            .Setup(s => s.TryGetValue(stubSessionObjectKey, out It.Ref<byte[]>.IsAny!))
+            .Returns(false);
+
+        Mock<IAspNetCoreSessionProvider> sessionProviderMock = new();
+        sessionProviderMock.Setup(t => t.GetSession()).Returns(sessionMock.Object);
+
+        Mock<ISessionObjectSerializer<StubSessionObject>> serializer = new();
+
+        AspNetCoreSessionQueryHandler<StubSessionObject> sut = new(sessionProviderMock.Object, keyResolver.Object, serializer.Object);
+
+        // Act
+        SessionQueryResponse<StubSessionObject> sessionQueryResponse = sut.GetSessionObject();
+
+        // Assert
+        Assert.Null(sessionQueryResponse.Value); // defaults
+        Assert.False(sessionQueryResponse.HasValue);
+
+        sessionProviderMock.Verify(t => t.GetSession(), Times.Once);
+    }
+
+    [Fact]
+    public void Session_Contains_Key_Returns_Deserialised_Object()
+    {
+        // Arrange
+        const string stubSessionObjectKey = "key";
+        Mock<ISessionObjectKeyResolver> keyResolver = new();
+        keyResolver.Setup(t => t.Resolve<StubSessionObject>()).Returns(stubSessionObjectKey);
+
+        byte[] stubTryGetSessionValueBytes = Encoding.UTF8.GetBytes("test-value");
+        Mock<ISession> sessionMock = new();
+        sessionMock
+            .Setup(session => session.TryGetValue(It.IsAny<string>(), out stubTryGetSessionValueBytes!))
+            .Returns(true);
+
+        Mock<IAspNetCoreSessionProvider> sessionProviderMock = new();
+        sessionProviderMock
+            .Setup(provider => provider.GetSession())
+            .Returns(sessionMock.Object);
+
+        StubSessionObject stubSessionObject = new();
+        Mock<ISessionObjectSerializer<StubSessionObject>> serializer = new();
+        serializer
+            .Setup((serializer) => serializer.Deserialize(It.IsAny<string>()))
+            .Returns(stubSessionObject)
+            .Verifiable();
+
+        AspNetCoreSessionQueryHandler<StubSessionObject> sut = new(sessionProviderMock.Object, keyResolver.Object, serializer.Object);
+
+        // Act
+        SessionQueryResponse<StubSessionObject> sessionQueryResponse = sut.GetSessionObject();
+
+        // Assert
+        Assert.Equal(stubSessionObject, sessionQueryResponse.Value);
+        Assert.True(sessionQueryResponse.HasValue);
+
+        sessionProviderMock.Verify(t => t.GetSession(), Times.Once);
+        serializer.Verify(t => t.Deserialize("test-value"), Times.Once);
+    }
+
+    public class StubSessionObject { }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/CompositionRootTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/CompositionRootTests.cs
@@ -1,0 +1,35 @@
+﻿using DfE.GIAP.Core.SharedTests.TestDoubles;
+using DfE.GIAP.SharedTests;
+using DfE.GIAP.Web.Session;
+using DfE.GIAP.Web.Session.Abstraction;
+using DfE.GIAP.Web.Session.Abstraction.Command;
+using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+public sealed class CompositionRootTests
+{
+    [Fact]
+    public void AddAspNetCoreSession_Resolves_Services()
+    {
+        IServiceProvider provider =
+            ServiceCollectionTestDoubles.Default()
+                .AddSingleton<IHttpContextAccessor>((sp) => new HttpContextAccessor())
+                .AddAspNetCoreSessionServices()
+                .BuildServiceProvider();
+
+        using IServiceScope scope = provider.CreateScope();
+        Assert.NotNull(provider.GetService<ISessionObjectKeyResolver>());
+
+        Assert.NotNull(scope.ServiceProvider.GetService<IAspNetCoreSessionProvider>());
+
+        Assert.NotNull(scope.ServiceProvider.GetService<ISessionCommandHandler<SessionObjectReferenceType>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<ISessionQueryHandler<SessionObjectReferenceType>>());
+        Assert.NotNull(scope.ServiceProvider.GetService<ISessionObjectSerializer<SessionObjectReferenceType>>());
+    }
+
+    public record SessionObjectReferenceType { }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/DefaultSessionObjectSerializer.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/DefaultSessionObjectSerializer.cs
@@ -1,0 +1,66 @@
+﻿using DfE.GIAP.Web.Session.Infrastructure.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+
+public sealed class DefaultSessionObjectSerializerTests
+{
+    private readonly DefaultSessionObjectSerializer<TestSessionObject> _serializer = new();
+
+    [Fact]
+    public void Serialize_ShouldReturnJsonString()
+    {
+        // Arrange
+        TestSessionObject sessionObject = new()
+        {
+            Id = 1,
+            Name = "Test"
+        };
+
+        // Act
+        string result = _serializer.Serialize(sessionObject);
+
+        // Assert
+        JObject response = JObject.Parse(result);
+        Assert.Equal(2, response.Children().Count());
+        Assert.Equal(1, (int)response["Id"]!);
+        Assert.Equal("Test", response["Name"]!.ToString());
+    }
+
+    [Fact]
+    public void Deserialize_MultiLineJson_ShouldWork()
+    {
+        // Arrange
+        string json = @"
+        {
+            ""Id"": 1,
+            ""Name"": ""Test""
+        }";
+
+        // Act
+        TestSessionObject result = _serializer.Deserialize(json);
+
+        // Assert
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Test", result.Name);
+    }
+
+
+    [Fact]
+    public void Deserialize_InvalidJson_ShouldThrow()
+    {
+        // Arrange
+        string invalidJson = "{invalid json}";
+
+        // Act & Assert
+        Assert.ThrowsAny<JsonException>(() => _serializer.Deserialize(invalidJson));
+    }
+
+    private class TestSessionObject
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/MappedToDataTransferObjectSessionObjectSerializerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/MappedToDataTransferObjectSessionObjectSerializerTests.cs
@@ -1,0 +1,106 @@
+﻿using System.Globalization;
+using DfE.GIAP.Core.SharedTests.TestDoubles;
+using DfE.GIAP.Web.Session.Infrastructure.Serialization;
+using Microsoft.Azure.Cosmos.Serialization.HybridRow;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+
+public class MappedToDataTransferObjectSessionObjectSerializerTests
+{
+    [Fact]
+    public void Serialize_ShouldMapComplexObjectToDtoAndSerialize()
+    {
+        // Arrange
+        SessionObjectStub expectedSessionObject = new(
+            Id: Guid.NewGuid(),
+            CreatedAt: DateTime.UtcNow,
+            Source: "System",
+            Version: 2);
+
+        DataTransferObjectStub expectedDto = new()
+        {
+            Id = expectedSessionObject.Id.ToString(),
+            CreatedAt = expectedSessionObject.CreatedAt.ToString("O"),
+            Metadata = new NestedTypeStub()
+            {
+                Source = expectedSessionObject.Source,
+                Version = expectedSessionObject.Version
+            }
+        };
+
+
+        MappedToDataTransferObjectSessionObjectSerializer<SessionObjectStub, DataTransferObjectStub> serializer = new(
+                MapperTestDoubles.MockFor<SessionObjectStub, DataTransferObjectStub>(expectedDto).Object,
+                MapperTestDoubles.MockFor<DataTransferObjectStub, SessionObjectStub>(expectedSessionObject).Object
+            );
+
+        // Act
+        string json = serializer.Serialize(expectedSessionObject);
+
+        // Assert
+        JObject response = JObject.Parse(json);
+        Assert.Equal(3, response.Children().Count());
+        Assert.Equal(expectedDto.Id, response["Id"]!);
+        Assert.Equal(expectedDto.CreatedAt, response["CreatedAt"]!);
+
+        Assert.Equal(2, response["Metadata"].Children().Count());
+        Assert.Equal("System", response["Metadata"]!["Source"]!.ToString());
+        Assert.Equal(2, (int)response["Metadata"]!["Version"]);
+    }
+
+    [Fact]
+    public void Deserialize_ShouldMapDtoBackToComplexObject()
+    {
+        // Arrange
+        DataTransferObjectStub dto = new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            CreatedAt = DateTime.UtcNow.ToString("O"),
+            Metadata = new NestedTypeStub()
+            {
+                Source = "System",
+                Version = 2
+            }
+        };
+
+        string dtoAsJson = JsonConvert.SerializeObject(dto);
+
+        SessionObjectStub expectedSessionObject = new(
+            Id: Guid.Parse(dto.Id),
+            CreatedAt: DateTime.Parse(dto.CreatedAt, CultureInfo.CurrentCulture),
+            Source: dto.Metadata.Source,
+            Version: dto.Metadata.Version);
+
+        MappedToDataTransferObjectSessionObjectSerializer<SessionObjectStub, DataTransferObjectStub> serializer = new(
+            MapperTestDoubles.MockFor<SessionObjectStub, DataTransferObjectStub>(dto).Object,
+            MapperTestDoubles.MockFor<DataTransferObjectStub, SessionObjectStub>(expectedSessionObject).Object);
+
+        // Act
+        SessionObjectStub result = serializer.Deserialize(dtoAsJson);
+
+        // Assert
+        Assert.Equal(expectedSessionObject.Id, result.Id);
+        Assert.Equal(expectedSessionObject.CreatedAt, result.CreatedAt);
+        Assert.Equal(expectedSessionObject.Source, result.Source);
+        Assert.Equal(expectedSessionObject.Version, result.Version);
+    }
+
+    public record SessionObjectStub(Guid Id, DateTime CreatedAt, string Source, int Version);
+
+    public class NestedTypeStub
+    {
+        public string Source { get; set; }
+        public int Version { get; set; }
+    }
+
+    public class DataTransferObjectStub
+    {
+        public string Id { get; set; }
+        public string CreatedAt { get; set; }
+        public NestedTypeStub Metadata { get; set; }
+    }
+}
+

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/SessionObjectKeyResolverTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/SessionObjectKeyResolverTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DfE.GIAP.Web.Session.Infrastructure;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Session;
+public sealed class SessionObjectKeyResolverTests
+{
+    [Theory]
+    [InlineData(typeof(NestedSessionObject), "DfE.GIAP.Web.Tests.Session.SessionObjectKeyResolverTests+NestedSessionObject")]
+    [InlineData(typeof(SessionObject), "DfE.GIAP.Web.Tests.Session.SessionObject")]
+    public void Resolves_Type_Returns_SessionKey_To_NamespaceAndType(Type type, string expectedKey)
+    {
+        SessionObjectKeyResolver sut = new();
+
+        // Act
+        string output = sut.Resolve(type);
+
+        Assert.Equal(expectedKey, output);
+    }
+
+    [Fact]
+    public void Resolves_GenericType_Returns_SessionKey_To_NamespaceAndType()
+    {
+        string expectedKey = "DfE.GIAP.Web.Tests.Session.SessionObject";
+
+        SessionObjectKeyResolver sut = new();
+
+        // Act
+        string output = sut.Resolve<SessionObject>();
+
+        Assert.Equal(expectedKey, output);
+    }
+
+    public class NestedSessionObject { }
+}
+
+public class SessionObject { }

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/IAspNetCoreSessionProviderTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/IAspNetCoreSessionProviderTestDoubles.cs
@@ -1,0 +1,20 @@
+﻿using DfE.GIAP.Web.Session.Infrastructure.AspNetCore;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace DfE.GIAP.Web.Tests.Session.TestDoubles;
+internal static class IAspNetCoreSessionProviderTestDoubles
+{
+    internal static Mock<IAspNetCoreSessionProvider> Default() => new();
+    internal static Mock<IAspNetCoreSessionProvider> MockWithSession(ISession session)
+    {
+        Mock<IAspNetCoreSessionProvider> mockProvider = Default();
+
+        mockProvider
+            .Setup(provider => provider.GetSession())
+            .Returns(session)
+            .Verifiable();
+
+        return mockProvider;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/ISessionObjectKeyResolverTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/ISessionObjectKeyResolverTestDoubles.cs
@@ -1,0 +1,21 @@
+﻿using DfE.GIAP.Web.Session.Abstraction;
+using Moq;
+
+namespace DfE.GIAP.Web.Tests.Session.TestDoubles;
+internal static class ISessionObjectKeyResolverTestDoubles
+{
+    internal static Mock<ISessionObjectKeyResolver> Default() => new();
+
+    internal static Mock<ISessionObjectKeyResolver> MockFor<TSessionObject>(string resolvedKey)
+    {
+        Mock<ISessionObjectKeyResolver> keyResolverMock = Default();
+
+        keyResolverMock.Setup(keyResolver => keyResolver.Resolve<TSessionObject>())
+            .Returns(resolvedKey)
+            .Verifiable();
+
+        return keyResolverMock;
+    }
+
+    internal static Mock<ISessionObjectKeyResolver> MockFor<TSessionObject>(Func<string> keyProvider) => MockFor<TSessionObject>(keyProvider());
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/ISessionObjectSerializerTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/ISessionObjectSerializerTestDoubles.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DfE.GIAP.Web.Session.Abstraction;
+using Moq;
+
+namespace DfE.GIAP.Web.Tests.Session.TestDoubles;
+internal static class ISessionObjectSerializerTestDoubles
+{
+    internal static Mock<ISessionObjectSerializer<TSessionObject>> Default<TSessionObject>() => new();
+
+    internal static Mock<ISessionObjectSerializer<TSessionObject>> MockDeserialize<TSessionObject>(TSessionObject stubSessionObject)
+    {
+        Mock<ISessionObjectSerializer<TSessionObject>> mockSerializer = Default<TSessionObject>();
+
+        mockSerializer
+            .Setup((serializer) => serializer.Deserialize(It.IsAny<string>()))
+            .Returns(stubSessionObject)
+            .Verifiable();
+
+        return mockSerializer;
+    }
+
+    internal static Mock<ISessionObjectSerializer<TSessionObject>> MockSerialize<TSessionObject>(string stubSerialisedValue)
+    {
+        Mock<ISessionObjectSerializer<TSessionObject>> mockSerializer = Default<TSessionObject>();
+
+        mockSerializer
+            .Setup((serializer) => serializer.Serialize(It.IsAny<TSessionObject>()))
+            .Returns(stubSerialisedValue)
+            .Verifiable();
+
+        return mockSerializer;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/ISessionTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Session/TestDoubles/ISessionTestDoubles.cs
@@ -1,0 +1,33 @@
+﻿using System.Text;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace DfE.GIAP.Web.Tests.Session.TestDoubles;
+internal interface ISessionTestDoubles
+{
+    internal static Mock<ISession> Default() => new();
+
+    internal static Mock<ISession> MockForTryGetValue(string key, bool tryGetResult)
+    {
+        Mock<ISession> mockSession = Default();
+
+        // Must match 
+        byte[] stubBytes = Encoding.UTF8.GetBytes(key);
+        mockSession
+            .Setup(session => session.TryGetValue(It.IsAny<string>(), out stubBytes!))
+            .Returns(tryGetResult);
+
+        return mockSession;
+    }
+
+    internal static Mock<ISession> MockForSet()
+    {
+        Mock<ISession> mockSession = Default();
+
+        mockSession
+            .Setup((session) => session.Set(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Verifiable();
+
+        return mockSession;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/Http/HttpContextTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/Http/HttpContextTestDoubles.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace DfE.GIAP.Web.Tests.TestDoubles.Http;
+internal static class HttpContextTestDoubles
+{
+
+    internal static HttpContext Default() => new DefaultHttpContext();
+
+    internal static HttpContext WithSession(ISession? session) => new DefaultHttpContext()
+    {
+        Session = session!
+    };
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/Http/IHttpContextAccessorTestDoubles.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/Http/IHttpContextAccessorTestDoubles.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace DfE.GIAP.Web.Tests.TestDoubles.Http;
+internal static class IHttpContextAccessorTestDoubles
+{
+    internal static Mock<IHttpContextAccessor> Default() => new();
+
+    internal static Mock<IHttpContextAccessor> WithHttpContext(HttpContext? httpContext)
+    {
+        Mock<IHttpContextAccessor> httpContextAccessorMock = Default();
+        httpContextAccessorMock.SetupGet(t => t.HttpContext).Returns(httpContext);
+        return httpContextAccessorMock;
+    }
+}


### PR DESCRIPTION
## 📌 Summary

breakoff the session abstraction from #256 

## 🔍 Related Issue(s)

Future issue to look at fully moving over to this over `ISessionProvider` in #259
## 🧪 Changes Made

- [x] feat – New feature

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
