### PR TITLE
pipeline: auto generate releases from tags

### DIFF
--- a/.github/workflows/web-application-cicd.yml
+++ b/.github/workflows/web-application-cicd.yml
@@ -328,25 +328,6 @@ jobs:
         with:
           url: ${{ needs.deploy_development.outputs.app_url }}
 
-  publish_github_release:
-    needs: [verify_development]
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
-          draft: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   ####
   ## Test Environment
   ####
@@ -388,6 +369,24 @@ jobs:
         uses: ./.github/actions/smoke-test
         with:
           url: ${{ needs.deploy_test.outputs.app_url }}
+
+  publish_github_release:
+    needs: [verify_test]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ##  PLACEHOLDERS FOR ADDITIONAL TESTS
   #  integration_test_env_test:


### PR DESCRIPTION
## 📌 Summary

- added `publish_github_release` job using `softprops/action-gh-release`
- Configured release to:
  - Trigger only on tag pushes
  - Generate release notes automatically
  - Publish immediately (no draft stage)
- Gated release behind:
  - Successful completion of `deploy_development`
  - Successful complete of `verify_development`

## 🔍 Related Issue(s)

<!-- Link to any related issues or tickets -->

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [x] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

<!-- Steps to test this PR locally -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots or recordings (e.g. GIFs) to help reviewers -->

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
