### PR TITLE
feat: GetSelectedMyPupilUniquePupilNumbersProvider

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/GetSelectedMyPupils/GetSelectedMyPupilUniquePupilNumbersProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/GetSelectedMyPupils/GetSelectedMyPupilUniquePupilNumbersProvider.cs
@@ -1,0 +1,33 @@
+﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Web.Features.MyPupils.State.Selection;
+using DfE.GIAP.Web.Session.Abstraction.Query;
+
+namespace DfE.GIAP.Web.Features.MyPupils.GetSelectedMyPupils;
+
+internal sealed class GetSelectedMyPupilUniquePupilNumbersProvider : IGetSelectedMyPupilsUniquePupilNumbersProvider
+{
+    private readonly ISessionQueryHandler<MyPupilsPupilSelectionState> _selectionStateSessionQueryHandler;
+
+    public GetSelectedMyPupilUniquePupilNumbersProvider(ISessionQueryHandler<MyPupilsPupilSelectionState> selectionStateSessionQueryHandler)
+    {
+        ArgumentNullException.ThrowIfNull(selectionStateSessionQueryHandler);
+        _selectionStateSessionQueryHandler = selectionStateSessionQueryHandler;
+    }
+
+    public UniquePupilNumbers GetSelectedMyPupils()
+    {
+        SessionQueryResponse<MyPupilsPupilSelectionState> sessionQueryResponse = _selectionStateSessionQueryHandler.GetSessionObject();
+
+        if (!sessionQueryResponse.HasValue)
+        {
+            return UniquePupilNumbers.Create(uniquePupilNumbers: []);
+        }
+
+        IEnumerable<UniquePupilNumber> selectedPupils =
+            sessionQueryResponse.Value.GetPupilsWithSelectionState()
+                .Where(t => t.Value)
+                .Select(t => t.Key);
+
+        return UniquePupilNumbers.Create(selectedPupils);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/GetSelectedMyPupils/IGetSelectedMyPupilsUniquePupilNumbersProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/GetSelectedMyPupils/IGetSelectedMyPupilsUniquePupilNumbersProvider.cs
@@ -1,0 +1,8 @@
+﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+
+namespace DfE.GIAP.Web.Features.MyPupils.GetSelectedMyPupils;
+
+public interface IGetSelectedMyPupilsUniquePupilNumbersProvider
+{
+    UniquePupilNumbers GetSelectedMyPupils();
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/GetSelectedMyPupils/GetSelectedMyPupilUniquePupilNumbersProviderTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/GetSelectedMyPupils/GetSelectedMyPupilUniquePupilNumbersProviderTests.cs
@@ -1,7 +1,9 @@
 ﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.SharedTests.TestDoubles;
 using DfE.GIAP.Web.Features.MyPupils.GetSelectedMyPupils;
 using DfE.GIAP.Web.Features.MyPupils.State.Selection;
 using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Tests.TestDoubles.MyPupils;
 using DfE.GIAP.Web.Tests.TestDoubles.Session;
 using Moq;
 using Xunit;
@@ -38,39 +40,37 @@ public sealed class GetSelectedMyPupilUniquePupilNumbersProviderTests
         Assert.Empty(result.GetUniquePupilNumbers());
     }
 
-    //[Fact]
-    //public void GetSelectedMyPupils_ReturnsOnlySelectedPupils()
-    //{
-    //    // Arrange
-    //    UniquePupilNumber upn1 = new("1234567890");
-    //    UniquePupilNumber upn2 = new("0987654321");
+    [Fact]
+    public void GetSelectedMyPupils_ReturnsOnlySelectedPupils()
+    {
+        // Arrange
+        List<UniquePupilNumber> uniquePupilsNumbers = UniquePupilNumberTestDoubles.Generate(2);
+        UniquePupilNumber selected = uniquePupilsNumbers[0];
+        UniquePupilNumber notSelected = uniquePupilsNumbers[1];
 
-    //    Dictionary<UniquePupilNumber, bool> selection = new()
-    //    {
-    //        [upn1] = true,
-    //        [upn2] = false
-    //    };
+        Dictionary<List<UniquePupilNumber>, bool> selection = new()
+        {
+            { [selected], true },
+            { [notSelected], false }
+        };
 
-    //    MyPupilsPupilSelectionState state = new(selection);
+        MyPupilsPupilSelectionState state = MyPupilsPupilSelectionStateTestDoubles.WithSelectionState(selection);
 
-    //    SessionQueryResponse<MyPupilsPupilSelectionState> response =
-    //        new SessionQueryResponse<MyPupilsPupilSelectionState>(hasValue: true, value: state);
+        // Arrange
+        Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>> sessionQueryHandlerMock =
+            ISessionQueryHandlerTestDoubles.MockFor(
+                SessionQueryResponse<MyPupilsPupilSelectionState>.Create(
+                    value: state));
 
-    //    Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>> mockHandler =
-    //        new Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>>();
+        GetSelectedMyPupilUniquePupilNumbersProvider provider = new(sessionQueryHandlerMock.Object);
 
-    //    mockHandler.Setup(h => h.GetSessionObject()).Returns(response);
+        // Act
+        UniquePupilNumbers result = provider.GetSelectedMyPupils();
 
-    //    GetSelectedMyPupilUniquePupilNumbersProvider provider =
-    //        new(mockHandler.Object);
-
-    //    // Act
-    //    UniquePupilNumbers result = provider.GetSelectedMyPupils();
-
-    //    // Assert
-    //    Assert.Single(result.Values);
-    //    Assert.Contains(upn1, result.Values);
-    //    Assert.DoesNotContain(upn2, result.Values);
-    //}
+        // Assert
+        UniquePupilNumber responseUniquePupilNumber = Assert.Single(result.GetUniquePupilNumbers());
+        Assert.Equal(selected, responseUniquePupilNumber);
+        Assert.DoesNotContain(notSelected, result.GetUniquePupilNumbers());
+    }
 }
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/GetSelectedMyPupils/GetSelectedMyPupilUniquePupilNumbersProviderTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/GetSelectedMyPupils/GetSelectedMyPupilUniquePupilNumbersProviderTests.cs
@@ -1,0 +1,76 @@
+﻿using DfE.GIAP.Core.MyPupils.Domain.ValueObjects;
+using DfE.GIAP.Web.Features.MyPupils.GetSelectedMyPupils;
+using DfE.GIAP.Web.Features.MyPupils.State.Selection;
+using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Tests.TestDoubles.Session;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.MyPupils.GetSelectedMyPupils;
+public sealed class GetSelectedMyPupilUniquePupilNumbersProviderTests
+{
+    [Fact]
+    public void Constructor_Throws_When_SessionQueryHandler_Is_Null()
+    {
+        // Arrange
+        Func<GetSelectedMyPupilUniquePupilNumbersProvider> construct =
+            () => new GetSelectedMyPupilUniquePupilNumbersProvider(null!);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void GetSelectedMyPupils_ReturnsEmpty_WhenSessionQueryResponseHasNoValue()
+    {
+        // Arrange
+        Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>> sessionQueryHandlerMock =
+            ISessionQueryHandlerTestDoubles.MockFor(
+                SessionQueryResponse<MyPupilsPupilSelectionState>.NoValue());
+
+        GetSelectedMyPupilUniquePupilNumbersProvider provider = new(sessionQueryHandlerMock.Object);
+
+        // Act
+        UniquePupilNumbers result = provider.GetSelectedMyPupils();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result.GetUniquePupilNumbers());
+    }
+
+    //[Fact]
+    //public void GetSelectedMyPupils_ReturnsOnlySelectedPupils()
+    //{
+    //    // Arrange
+    //    UniquePupilNumber upn1 = new("1234567890");
+    //    UniquePupilNumber upn2 = new("0987654321");
+
+    //    Dictionary<UniquePupilNumber, bool> selection = new()
+    //    {
+    //        [upn1] = true,
+    //        [upn2] = false
+    //    };
+
+    //    MyPupilsPupilSelectionState state = new(selection);
+
+    //    SessionQueryResponse<MyPupilsPupilSelectionState> response =
+    //        new SessionQueryResponse<MyPupilsPupilSelectionState>(hasValue: true, value: state);
+
+    //    Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>> mockHandler =
+    //        new Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>>();
+
+    //    mockHandler.Setup(h => h.GetSessionObject()).Returns(response);
+
+    //    GetSelectedMyPupilUniquePupilNumbersProvider provider =
+    //        new(mockHandler.Object);
+
+    //    // Act
+    //    UniquePupilNumbers result = provider.GetSelectedMyPupils();
+
+    //    // Assert
+    //    Assert.Single(result.Values);
+    //    Assert.Contains(upn1, result.Values);
+    //    Assert.DoesNotContain(upn2, result.Values);
+    //}
+}
+


### PR DESCRIPTION
## 📌 Summary

continuing from #274 this implements the remaining provider that downloads require as per #220 to retrieve previously selected pupils from state, so they can be joined with the inbound selectedPupils, to send off for Downloading pupil data.

## 🔍 Related Issue(s)

#148 

## 🧪 Changes Made

- [x] feat – New feature

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
