### PR TITLE
pipeline: Remove (branch == main) guard on deploy_dev, deploy_test for autogenerating release-notes

### DIFF
--- a/.github/workflows/web-application-cicd.yml
+++ b/.github/workflows/web-application-cicd.yml
@@ -296,7 +296,6 @@ jobs:
     permissions:
       contents: read  # Required to check out the code.
       id-token: write # Required for OIDC authentication with Azure
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: development
     outputs:
@@ -338,7 +337,6 @@ jobs:
     permissions:
       contents: read  # Required to check out the code.
       id-token: write # Required for OIDC authentication with Azure
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: test
     outputs:


### PR DESCRIPTION

## 📌 Summary

As we are pushing tags for GitHub release notes to be generated see #270, we should autogenerate at the point of deploy-test being successful when the push was a tag. This removes the deploy to dev/test guard that requires the **branch** to be main.

## 🔍 Related Issue(s)

#207 

## 🧪 Changes Made

- [x] pipeline – CI/CD or workflow updates

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
