### PR TITLE
fix: updated popular activities data downloads url 

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Views/Shared/Layout/_LayoutSideMenuPopularActivities.cshtml
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Views/Shared/Layout/_LayoutSideMenuPopularActivities.cshtml
@@ -33,7 +33,7 @@
                         </a>
                     </li>
                     <li>
-                        <a asp-controller="PreparedDownloads" asp-action="GetPreparedDownloads" class="govuk-link" id="popular-activities--downloads--link">
+                        <a asp-controller="PreparedDownloads" asp-action="Index" class="govuk-link" id="popular-activities--downloads--link">
                             Data downloads
                         </a>
                     </li>


### PR DESCRIPTION
## 📌 Summary

- fixes bug with data-download popular activities url pointing to wrong controller method

## 🔍 Related Issue(s)

<!-- Link to any related issues or tickets -->

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

<!-- Steps to test this PR locally -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots or recordings (e.g. GIFs) to help reviewers -->

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
