### PR TITLE
refactor: remove unused property and filename column

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/PreparedFileViewModel.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/PreparedFileViewModel.cs
@@ -12,6 +12,4 @@ public class PreparedFileViewModel
     public string DisplayName =>
         string.IsNullOrEmpty(FileName) ? null :
         FileName.Contains('.') ? FileName.Substring(0, FileName.LastIndexOf('.')) : FileName;
-
-    public string Link { get; set; }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Views/Shared/_MetaDataDownloadListPartial.cshtml
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Views/Shared/_MetaDataDownloadListPartial.cshtml
@@ -6,7 +6,6 @@
 
         {
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell" id="downloads--downloads-data-name--text-@i">@Html.Raw(Model.PreparedMetadataFiles[i].DisplayName)</td>
                 <td class="govuk-table__cell" id="downloads--downloads-data-date--text-@i">@Html.Raw(Model.PreparedMetadataFiles[i].Date.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture))</td>
                 <td class="govuk-table__cell">
                     <a asp-action="GetBulkUploadTemplateFile" asp-controller="Glossary" asp-route-name="@Html.Raw(Model.PreparedMetadataFiles[i].FileName)" class="downloads--downloads-data-link--link govuk-link" id="downloads--downloads-data-link--link-@i" download>@Html.Raw(Model.PreparedMetadataFiles[i].FileName)</a>


### PR DESCRIPTION
## 📌 Summary

- removes unused `Link` property within prepared file model
- removes `Filename` column for metadata prepared view

## 🔍 Related Issue(s)

- #293 

<!-- Link to any related issues or tickets -->

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [x] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

<!-- Steps to test this PR locally -->

## 📸 Screenshots (if applicable)

<img width="817" height="572" alt="image" src="https://github.com/user-attachments/assets/f8621519-f5f4-4c50-b5cb-d0b7be7b3448" />

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
