### PR TITLE
tests: SharedTests.Infrastructure add PartitionKeyType to CosmosDbContainerOptions to enable DOCTYPE and other integer-partiton-keys

### DIFF
--- a/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/TestHarness/CosmosDbFixture.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Core.IntegrationTests/TestHarness/CosmosDbFixture.cs
@@ -10,7 +10,7 @@ public sealed class CosmosDbFixture : BaseCosmosDbFixture
             new CosmosDbDatabaseOptions(
                 databaseName: DatabaseName,
                 containers: [
-                    new("application-data", "/DOCTYPE" ),
+                    new("application-data", "/DOCTYPE", PartitionKeyType.Integer ),
                     new("news", "/id" ),
                     new("users", "/id" ),
                     new("mypupils", "/id")

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbContainerOptions.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbContainerOptions.cs
@@ -3,13 +3,22 @@ public record CosmosDbContainerOptions
 {
     public string ContainerName { get; }
     public string PartitionKey { get; }
+    public PartitionKeyType PartitionKeyType { get; }
 
-    public CosmosDbContainerOptions(string containerName, string partitionKey = "/id")
+    public CosmosDbContainerOptions(string containerName, string partitionKey = "/id", PartitionKeyType type = PartitionKeyType.String)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
         ContainerName = containerName;
 
         ArgumentException.ThrowIfNullOrWhiteSpace(partitionKey);
         PartitionKey = partitionKey.StartsWith('/') ? partitionKey : $"/{partitionKey}";
+
+        PartitionKeyType = type;
     }
+}
+
+public enum PartitionKeyType
+{
+    Integer,
+    String
 }


### PR DESCRIPTION
## 📌 Summary

Continue from #373 remove a GIAP specific `application-data` reference from the SharedTests.Infrastructure CosmosDb Fixture

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [x] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
