### PR TITLE
tests: Make SharedTests.Infrastructure target netstandard2.0

### DIFF
--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/BaseCosmosDbFixture.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/BaseCosmosDbFixture.cs
@@ -17,7 +17,7 @@ public abstract class BaseCosmosDbFixture : IAsyncLifetime
     {
         Dictionary<string, CosmosDbDatabaseClient> clients = [];
 
-        ArgumentNullException.ThrowIfNull(Options);
+        Guard.ThrowIfNull(Options, nameof(CosmosDbOptions));
 
         foreach (string databaseName in Options.DatabaseNames)
         {
@@ -59,7 +59,7 @@ public abstract class BaseCosmosDbFixture : IAsyncLifetime
 
     private CosmosDbDatabaseClient GetDatabaseClientByName(string databaseName)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
+        Guard.ThrowIfNullOrWhiteSpace(databaseName, nameof(databaseName));
 
         CosmosDbDatabaseClient client =
             _dbClients.Single(t => t.Key.Equals(databaseName, StringComparison.Ordinal))

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/CosmosDbTestDatabase.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/CosmosDbTestDatabase.cs
@@ -84,7 +84,7 @@ public class CosmosDbDatabaseClient : IAsyncDisposable
 
     public async Task<List<TDto>> ReadManyAsync<TDto>(string containerName, IEnumerable<string>? identifiers = null) where TDto : class
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
+        Guard.ThrowIfNullOrWhiteSpace(containerName, nameof(containerName));
         ContainerResponse targetContainer = await GetContainerByName(containerName);
 
         // Build the query string
@@ -148,7 +148,7 @@ public class CosmosDbDatabaseClient : IAsyncDisposable
 
     private async Task<List<ContainerResponse>> CreateAllContainersIfNotExistAsync(Database database)
     {
-        ArgumentNullException.ThrowIfNull(database);
+        Guard.ThrowIfNull(database, nameof(database));
         List<ContainerResponse> containerResponses = [];
 
         foreach (CosmosDbContainerOptions options in _containerOptions)

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbContainerOptions.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbContainerOptions.cs
@@ -7,11 +7,11 @@ public record CosmosDbContainerOptions
 
     public CosmosDbContainerOptions(string containerName, string partitionKey = "/id", PartitionKeyType type = PartitionKeyType.String)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
+        Guard.ThrowIfNullOrWhiteSpace(containerName, nameof(containerName));
         ContainerName = containerName;
 
-        ArgumentException.ThrowIfNullOrWhiteSpace(partitionKey);
-        PartitionKey = partitionKey.StartsWith('/') ? partitionKey : $"/{partitionKey}";
+        Guard.ThrowIfNullOrWhiteSpace(partitionKey, nameof(partitionKey));
+        PartitionKey = partitionKey.StartsWith("/") ? partitionKey : $"/{partitionKey}";
 
         PartitionKeyType = type;
     }

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbDatabaseOptions.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbDatabaseOptions.cs
@@ -6,7 +6,7 @@ public record CosmosDbDatabaseOptions
 
     public CosmosDbDatabaseOptions(string databaseName, IEnumerable<CosmosDbContainerOptions>? containers)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
+        Guard.ThrowIfNullOrWhiteSpace(databaseName, nameof(databaseName));
         DatabaseName = databaseName;
         Containers = (containers ?? []).ToList().AsReadOnly();
     }

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbOptions.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/CosmosDb/Options/CosmosDbOptions.cs
@@ -26,7 +26,7 @@ public record CosmosDbOptions
 
     public CosmosDbOptions(string uri, string? key, IEnumerable<CosmosDbDatabaseOptions> databaseOptions)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(uri);
+        Guard.ThrowIfNullOrWhiteSpace(uri, nameof(uri));
         if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? result))
         {
             throw new ArgumentException("Invalid URI format", nameof(uri));

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/DfE.GIAP.SharedTests.Infrastructure.csproj
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/DfE.GIAP.SharedTests.Infrastructure.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	<RootNamespace>DfE.GIAP.SharedTests.Infrastructure</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/Guard.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/Guard.cs
@@ -1,0 +1,20 @@
+﻿namespace DfE.GIAP.SharedTests.Infrastructure;
+
+internal static class Guard
+{
+    internal static void ThrowIfNull<T>(T value, string paramName)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+    }
+
+    internal static void ThrowIfNullOrWhiteSpace(string value, string paramName)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException($"{paramName} cannot be null or empty");
+        }
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/SearchIndex/AzureSearchIndexClient.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/SearchIndex/AzureSearchIndexClient.cs
@@ -11,7 +11,7 @@ internal sealed class AzureSearchIndexClient
 
     public AzureSearchIndexClient(IWireMockClient wireMockClient)
     {
-        ArgumentNullException.ThrowIfNull(wireMockClient);
+        Guard.ThrowIfNull(wireMockClient, nameof(wireMockClient));
         _wireMockClient = wireMockClient;
     }
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/SearchIndex/SearchIndexFixture.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/SearchIndex/SearchIndexFixture.cs
@@ -35,7 +35,7 @@ public sealed class SearchIndexFixture : IDisposable
 
     public async Task StubIndex(string indexName, IEnumerable<object>? values = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
+        Guard.ThrowIfNullOrWhiteSpace(indexName, nameof(indexName));
         List<object> azureIndexDtos = values is null ? [] : values.ToList();
         await _searchIndex.StubIndexSearchResponse(indexName, azureIndexDtos);
     }

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/RequestMatch.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/RequestMatch.cs
@@ -24,15 +24,19 @@ public class RequestMatch
 
     private static string NormalisePath(string? input)
     {
+        char forwardSlash = '/';
+
         if (string.IsNullOrEmpty(input))
         {
-            return "/";
+            return forwardSlash.ToString();
         }
-        if (input.StartsWith('/'))
+
+        if (input!.StartsWith(forwardSlash.ToString()))
         {
-            return input.TrimEnd('/');
+            return input.TrimEnd(forwardSlash);
         }
-        return $"/{input}".TrimEnd('/');
+
+        return $"/{input}".TrimEnd(forwardSlash);
     }
 
     private static string BuildQueryString(IEnumerable<KeyValuePair<string, string?>>? query)


### PR DESCRIPTION
## 📌 Summary

Current `Azure.Core` in the tests is the lowest target; netstandard2.0 which will mean consumable in netcore2.0+  and netframework4.7.2+.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [x] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
