### PR TITLE
[WIP] tests:  SharedTests.Infrastructure adopt RestClient

### DIFF
--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/DfE.GIAP.SharedTests.Infrastructure.csproj
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/DfE.GIAP.SharedTests.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="WireMock.Net" />
+    <PackageReference Include="WireMock.Net.RestClient" />
     <PackageReference Include="xunit" />
   </ItemGroup>
 </Project>

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/SearchIndex/AzureSearchIndexStubClient.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/SearchIndex/AzureSearchIndexStubClient.cs
@@ -7,9 +7,9 @@ namespace DfE.GIAP.SharedTests.Infrastructure.SearchIndex;
 
 internal sealed class AzureSearchIndexStubClient
 {
-    private readonly IWireMockClient _wireMockClient;
+    private readonly IWireMockStubClient _wireMockClient;
 
-    public AzureSearchIndexStubClient(IWireMockClient wireMockClient)
+    public AzureSearchIndexStubClient(IWireMockStubClient wireMockClient)
     {
         Guard.ThrowIfNull(wireMockClient, nameof(wireMockClient));
         _wireMockClient = wireMockClient;

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/IWireMockStubClient.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/IWireMockStubClient.cs
@@ -1,5 +1,5 @@
 ﻿namespace DfE.GIAP.SharedTests.Infrastructure.WireMock.Server.Client;
-public interface IWireMockClient
+public interface IWireMockStubClient
 {
     Task Stub<TDataTransferObject>(
         RequestMatch request,

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/WireMockHttpClient.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/WireMockHttpClient.cs
@@ -2,19 +2,17 @@
 using Newtonsoft.Json;
 
 namespace DfE.GIAP.SharedTests.Infrastructure.WireMock.Server.Client;
-internal sealed class WireMockRemoteClient : IWireMockClient
+internal sealed class WireMockHttpClient : IWireMockStubClient
 {
-    // TODO RestClient shipped from WireMock native
     private readonly HttpClient _httpClient;
 
-    public WireMockRemoteClient(HttpClient client)
+    public WireMockHttpClient(HttpClient client)
     {
         _httpClient = client;
     }
 
     public async Task Stub<TDataTransferObject>(RequestMatch request, Response<TDataTransferObject> response)
     {
-        // TODO use a WireMock type from WireMock library than anon object serialise
         var stub = new
         {
             request = new

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/WireMockLocalProcessStubClient.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/WireMockLocalProcessStubClient.cs
@@ -5,11 +5,11 @@ using WireMock.Server;
 
 namespace DfE.GIAP.SharedTests.Infrastructure.WireMock.Server.Client;
 
-internal sealed class WireMockLocalClient : IWireMockClient
+internal sealed class WireMockLocalProcessStubClient : IWireMockStubClient
 {
     private readonly WireMockServer _wireMockServer;
 
-    public WireMockLocalClient(WireMockServer wireMockServer)
+    public WireMockLocalProcessStubClient(WireMockServer wireMockServer)
     {
         Guard.ThrowIfNull(wireMockServer, nameof(wireMockServer));
         _wireMockServer = wireMockServer;

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/WireMockRefitStubClient.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Client/WireMockRefitStubClient.cs
@@ -1,0 +1,26 @@
+﻿using RestEase;
+using WireMock.Admin.Mappings;
+using WireMock.Org.RestClient;
+
+namespace DfE.GIAP.SharedTests.Infrastructure.WireMock.Server.Client;
+internal sealed class WireMockRefitStubClient : IWireMockStubClient
+{
+    private readonly IWireMockOrgApi _adminApi;
+
+    public WireMockRefitStubClient(Uri serverAddress)
+    {
+        _adminApi = RestClient.For<IWireMockOrgApi>(serverAddress);
+    }
+
+    public Task Stub<TDataTransferObject>(RequestMatch request, Response<TDataTransferObject> response)
+    {
+        MappingModelBuilder mappingBuilder = new();
+
+        mappingBuilder
+            .WithRequest((r) => r.WithMethods(request.Method).WithUrl(request.PathAndQueryString))
+            .WithResponse((res) => res.WithStatusCode(response.StatusCode).WithBodyAsJson(response.Body)));
+
+        return Task.CompletedTask;
+        /*_adminApi.PostAdminMappingsAsync();*/
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Host/IWireMockServerHost.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Host/IWireMockServerHost.cs
@@ -6,5 +6,5 @@ public interface IWireMockServerHost : IDisposable
 {
     Uri Endpoint { get; }
     Task StartAsync();
-    IWireMockClient CreateClient();
+    IWireMockStubClient CreateClient();
 }

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Host/LocalProcessWireMockServerHost.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Host/LocalProcessWireMockServerHost.cs
@@ -24,7 +24,7 @@ internal class LocalProcessWireMockServerHost : IWireMockServerHost
     }
     public Uri Endpoint => _serverUri;
 
-    public IWireMockClient CreateClient() => new WireMockLocalClient(_server.Value);
+    public IWireMockStubClient CreateClient() => new WireMockLocalProcessStubClient(_server.Value);
 
     public Task StartAsync()
     {

--- a/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Host/RemoteWireMockServerHost.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.SharedTests.Infrastructure/WireMock/Server/Host/RemoteWireMockServerHost.cs
@@ -18,9 +18,10 @@ internal class RemoteWireMockServerHost : IWireMockServerHost
 
     public Uri Endpoint => _serverOptions.ServerAddress;
 
-    public IWireMockClient CreateClient()
+    public IWireMockStubClient CreateClient()
     {
-        WireMockRemoteClient client = new(_sharedServerHttpClient);
+        WireMockHttpClient client = new(_sharedServerHttpClient);
+        //WireMockRefitStubClient client = new(Endpoint);
         return client;
     }
 

--- a/DfE.GIAP.All/tests/Directory.Packages.props
+++ b/DfE.GIAP.All/tests/Directory.Packages.props
@@ -14,6 +14,8 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="WireMock.Net" Version="1.15.0" />
     <PackageVersion Include="WireMock.Net.Abstractions" Version="1.15.0" />
+    <PackageVersion Include="WireMock.Net.RestClient" Version="1.15.0" />
+    <PackageVersion Include="WireMock.Org.RestClient" Version="1.15.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## 📌 Summary


Current we're posting serialised anonymous objects over HTTP in `WireMockRemoteHttpClient` to `wiremock:wiremock` image which is the java-server. It'd be better to use a native-client with generated models.

There is a [C# RefitClient](https://github.com/wiremock/WireMock.Net/blob/master/src/WireMock.Net.RestClient/WireMock.Net.RestClient.csproj) which provides a client and contract models to interact with WireMock. This doesn't work with `wiremock:wiremock` java image, it's suggested to work with the custom image see [wiremock issue](https://github.com/wiremock/WireMock.Net/issues/1061) which shows the issue with `Unprocessable entity`.

There is a [RefitClient for the java-server `wiremock:wiremock`](https://github.com/wiremock/WireMock.Net/blob/master/src/WireMock.Org.RestClient/WireMock.Org.RestClient.csproj) which could sit in place for the raw HttpClient usage.

## TODOs

- [ ] test if the RefitClient works with the other wiremock image
  - [ ] understand the other image difference
  - [ ] add to the docker-compose and test out consumption

- [ ] test if the RefitClient:Java provides better models to build the shapes and post.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [x] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
