### PR TITLE
chore: Fix no longer supported openjdk:26-slim tag for CertGenerator initcontainer

### DIFF
--- a/Dockerfile.CertGenerator
+++ b/Dockerfile.CertGenerator
@@ -1,4 +1,5 @@
-FROM openjdk:26-slim
+FROM mcr.microsoft.com/openjdk/jdk:25-ubuntu
+
 
 RUN apt-get update \
     && apt-get install -y openssl \


### PR DESCRIPTION
## 📌 Summary

It looks like the OpenJDK containers ( we use it as an `initcontainer` to run openssl, keytool to generate our certificates for WireMock) have changed the tags on docker-hub. We can either use the `ea` tag for early-access; e.g `openjdk:25-ea-slim`. 

I've just decided to use mcr and a stable tag - because allegedly the `openjdk` images on dockerhub are deprecated, and it's recommended to swap to one of the vendors providing openjdk. We already use mcr for cosmosdb, they also provide a openjdk image with same java tools in there.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [x] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
