### PR TITLE
fix: auth serialisation for age claims

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Extensions/ClaimsPrincipalExtension.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Extensions/ClaimsPrincipalExtension.cs
@@ -169,13 +169,13 @@ public static class ClaimsPrincipalExtension
     public static int GetOrganisationLowAge(this ClaimsPrincipal principal)
     {
         string lowAge = principal.GetClaimValue(AuthClaimTypes.OrganisationLowAge);
-        return int.TryParse(lowAge, out var age) ? age : 0; // Default to 0 if parsing fails
+        return int.TryParse(lowAge, out int age) ? age : 0; // Default to 0 if parsing fails
     }
 
     public static int GetOrganisationHighAge(this ClaimsPrincipal principal)
     {
         string highAge = principal.GetClaimValue(AuthClaimTypes.OrganisationHighAge);
-        return int.TryParse(highAge, out var age) ? age : 0; // Default to 0 if parsing fails
+        return int.TryParse(highAge, out int age) ? age : 0; // Default to 0 if parsing fails
     }
 
     public static string GetEstablishmentNumber(this ClaimsPrincipal principal)

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/DfeHttpSignInApiClient.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/DfeHttpSignInApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using DfE.GIAP.Web.Features.Auth.Application;
 using DfE.GIAP.Web.Features.Auth.Application.Models;
+using Newtonsoft.Json;
 
 namespace DfE.GIAP.Web.Features.Auth.Infrastructure;
 
@@ -34,6 +35,8 @@ public class DfeHttpSignInApiClient : IDfeSignInApiClient
 
         HttpResponseMessage response = await _httpClient.GetAsync(url);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<List<Organisation>>() ?? new List<Organisation>();
+
+        string json = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<List<Organisation>>(json) ?? new List<Organisation>();
     }
 }


### PR DESCRIPTION
## 📌 Summary

An issue occured when MAT/SAT users tries to login, this is down to the default `system.text.json` being stricter compared to `newtonsoft` library. Previously, `newtonsoft` will infer `int` -> `string` however, `system.text.json` will need extra config. For now I've reverted the change as a temp fix, might return to `system.text.json` in the future.

- reverting json deserialisation from `systen.text.json` to `newtonsoft` as patch for age claims throwing exceptions

## 🔍 Related Issue(s)

<!-- Link to any related issues or tickets -->

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

<!-- Steps to test this PR locally -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots or recordings (e.g. GIFs) to help reviewers -->

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
