### PR TITLE
fix: prepared downloads deserialisation

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/CompositionRoot.cs
@@ -1,9 +1,13 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
+using DfE.GIAP.Core.Common.CrossCutting;
 using DfE.GIAP.Web.Features.Auth.Application;
+using DfE.GIAP.Web.Features.Auth.Application.Models;
 using DfE.GIAP.Web.Features.Auth.Application.PostTokenHandlers;
 using DfE.GIAP.Web.Features.Auth.Infrastructure;
 using DfE.GIAP.Web.Features.Auth.Infrastructure.Config;
+using DfE.GIAP.Web.Features.Auth.Infrastructure.DataTransferObjects;
+using DfE.GIAP.Web.Features.Auth.Infrastructure.Mappers;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
@@ -23,6 +27,8 @@ public static class CompositionRoot
         // Core application services
         services.AddScoped<IClaimsEnricher, DfeClaimsEnricher>();
         services.AddSingleton<ISigningCredentialsProvider, SymmetricSigningCredentialsProvider>();
+
+        services.AddScoped<IMapper<OrganisationDto, Organisation>, OrganisationDtoToEntityOrganisation>();
 
         services.AddScoped<IPostTokenValidatedHandler, ClaimsEnrichmentHandler>();
         services.AddScoped<IPostTokenValidatedHandler, CreateUserIfNotExistHandler>();

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/DataTransferObjects/OrganisationDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/DataTransferObjects/OrganisationDto.cs
@@ -1,0 +1,47 @@
+﻿using Newtonsoft.Json;
+
+namespace DfE.GIAP.Web.Features.Auth.Infrastructure.DataTransferObjects;
+
+public class OrganisationDto
+{
+    [JsonProperty("id")]
+    public string Id { get; set; } = string.Empty;
+    [JsonProperty("name")]
+    public string? Name { get; set; }
+    [JsonProperty("category")]
+    public OrganisationCategoryDto? Category { get; set; }
+    [JsonProperty("type")]
+    public EstablishmentTypeDto? EstablishmentType { get; set; }
+    [JsonProperty("statutoryLowAge")]
+    public string? StatutoryLowAge { get; set; }
+    [JsonProperty("statutoryHighAge")]
+    public string? StatutoryHighAge { get; set; }
+    [JsonProperty("establishmentNumber")]
+    public string? EstablishmentNumber { get; set; }
+    [JsonProperty("localAuthority")]
+    public LocalAuthorityDto? LocalAuthority { get; set; }
+    [JsonProperty("urn")]
+    public string? UniqueReferenceNumber { get; set; }
+    [JsonProperty("uid")]
+    public string? UniqueIdentifier { get; set; }
+    [JsonProperty("ukprn")]
+    public string? UKProviderReferenceNumber { get; set; }
+}
+
+public class OrganisationCategoryDto
+{
+    [JsonProperty("id")]
+    public string Id { get; set; } = string.Empty;
+}
+
+public class EstablishmentTypeDto
+{
+    [JsonProperty("id")]
+    public string Id { get; set; } = string.Empty;
+}
+
+public class LocalAuthorityDto
+{
+    [JsonProperty("code")]
+    public string Code { get; set; } = string.Empty;
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/DfeClaimsEnricher.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/DfeClaimsEnricher.cs
@@ -13,7 +13,9 @@ public class DfeClaimsEnricher : IClaimsEnricher
     private readonly IDfeSignInApiClient _apiClient;
     private readonly DsiOptions _dsiOptions;
 
-    public DfeClaimsEnricher(IDfeSignInApiClient apiClient, IOptions<DsiOptions> options)
+    public DfeClaimsEnricher(
+        IDfeSignInApiClient apiClient,
+        IOptions<DsiOptions> options)
     {
         ArgumentNullException.ThrowIfNull(apiClient);
         ArgumentNullException.ThrowIfNull(options.Value);

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/Mappers/OrganisationDtoToEntityOrganisation.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Auth/Infrastructure/Mappers/OrganisationDtoToEntityOrganisation.cs
@@ -1,0 +1,37 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Web.Features.Auth.Application.Models;
+using DfE.GIAP.Web.Features.Auth.Infrastructure.DataTransferObjects;
+
+namespace DfE.GIAP.Web.Features.Auth.Infrastructure.Mappers;
+
+internal class OrganisationDtoToEntityOrganisation : IMapper<OrganisationDto, Organisation>
+{
+    public Organisation Map(OrganisationDto input)
+    {
+        if (input is null)
+        {
+            throw new ArgumentNullException(nameof(input), "Mapping input cannot be null.");
+        }
+
+        return new Organisation
+        {
+            Id = input.Id,
+            Name = input.Name,
+            Category = input.Category is not null
+            ? new OrganisationCategory { Id = input.Category.Id }
+            : null,
+            EstablishmentType = input.EstablishmentType is not null
+            ? new EstablishmentType { Id = input.EstablishmentType.Id }
+            : null,
+            StatutoryLowAge = input.StatutoryLowAge,
+            StatutoryHighAge = input.StatutoryHighAge,
+            EstablishmentNumber = input.EstablishmentNumber,
+            LocalAuthority = input.LocalAuthority is not null
+            ? new LocalAuthority { Code = input.LocalAuthority.Code }
+            : null,
+            UniqueReferenceNumber = input.UniqueReferenceNumber,
+            UniqueIdentifier = input.UniqueIdentifier,
+            UKProviderReferenceNumber = input.UKProviderReferenceNumber
+        };
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Auth/Infrastructure/DfeHttpSignInApiClientTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Auth/Infrastructure/DfeHttpSignInApiClientTests.cs
@@ -1,7 +1,11 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
+using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.SharedTests.TestDoubles;
 using DfE.GIAP.Web.Features.Auth.Application.Models;
 using DfE.GIAP.Web.Features.Auth.Infrastructure;
+using DfE.GIAP.Web.Features.Auth.Infrastructure.DataTransferObjects;
+using Moq;
 using Xunit;
 
 namespace DfE.GIAP.Web.Tests.Features.Auth.Infrastructure;
@@ -11,13 +15,15 @@ public class DfeHttpSignInApiClientTests
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WithNullHttpClient()
     {
-        Assert.Throws<ArgumentNullException>(() => new DfeHttpSignInApiClient(null!));
+        Mock<IMapper<OrganisationDto, Organisation>> mockMapper = MapperTestDoubles.Default<OrganisationDto, Organisation>();
+        Assert.Throws<ArgumentNullException>(() => new DfeHttpSignInApiClient(null!, mockMapper.Object));
     }
 
     [Fact]
     public async Task GetUserInfo_CallsCorrectUrl_And_DeserialisesResponse()
     {
         // Arrange
+        Mock<IMapper<OrganisationDto, Organisation>> mockMapper = MapperTestDoubles.Default<OrganisationDto, Organisation>();
         UserAccess expected = new()
         {
             Roles = new List<UserRole> {
@@ -32,7 +38,7 @@ public class DfeHttpSignInApiClientTests
         {
             BaseAddress = new Uri("https://fake.local")
         };
-        DfeHttpSignInApiClient sut = new(client);
+        DfeHttpSignInApiClient sut = new(client, mockMapper.Object);
 
         // Act
         UserAccess? result = await sut.GetUserInfo("svc1", "org1", "user1");
@@ -44,9 +50,10 @@ public class DfeHttpSignInApiClientTests
     }
 
     [Fact]
-    public async Task GetUserOrganisations_CallsCorrectUrl_And_DeserialisesResponse()
+    public async Task GetUserOrganisations_CallsCorrectUrl_And_MapperCalled()
     {
         // Arrange
+        Mock<IMapper<OrganisationDto, Organisation>> mockMapper = MapperTestDoubles.Default<OrganisationDto, Organisation>();
         List<Organisation> expected = new() {
             new Organisation {
                 Id = "org1",
@@ -60,35 +67,45 @@ public class DfeHttpSignInApiClientTests
         {
             BaseAddress = new Uri("https://fake.local")
         };
-        DfeHttpSignInApiClient sut = new(client);
+        DfeHttpSignInApiClient sut = new(client, mockMapper.Object);
 
         // Act
         List<Organisation> result = await sut.GetUserOrganisations("user1");
 
         // Assert
         Assert.Single(result);
-        Assert.Equal("org1", result[0].Id);
         Assert.Equal("/users/user1/organisations", handler.CapturedRequests[0].RequestUri!.PathAndQuery);
+        mockMapper.Verify(
+           (mapper) => mapper.Map(It.IsAny<OrganisationDto>()),
+           Times.Exactly(expected.Count));
     }
 
+
     [Fact]
-    public async Task GetUserOrganisation_FiltersOrganisationCorrectly()
+    public async Task GetUserOrganisation_ReturnsOrganisation_WhenFound()
     {
-        // Arrange
-        List<Organisation> organisations = new()
+        // Arrange DTOs
+        List<OrganisationDto> organisationDtos = new()
         {
-            new Organisation { Id = "org1", Name = "Org One" },
-            new Organisation { Id = "org2", Name = "Org Two" }
+            new OrganisationDto { Id = "org1", Name = "Org One" },
+            new OrganisationDto { Id = "org2", Name = "Org Two" }
         };
 
+        // Mock mapper to convert DTOs → Organisations based on Id/Name
+        Mock<IMapper<OrganisationDto, Organisation>> mockMapper = new();
+        mockMapper
+            .Setup(m => m.Map(It.IsAny<OrganisationDto>()))
+            .Returns<OrganisationDto>(dto => new Organisation { Id = dto.Id, Name = dto.Name });
+
+        // Stub HTTP handler to return DTO JSON
         StubHttpMessageHandler handler = new(_ =>
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(organisations) });
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(organisationDtos)
+            });
 
-        HttpClient client = new(handler)
-        {
-            BaseAddress = new Uri("https://fake.local")
-        };
-        DfeHttpSignInApiClient sut = new(client);
+        HttpClient client = new(handler) { BaseAddress = new Uri("https://fake.local") };
+        DfeHttpSignInApiClient sut = new(client, mockMapper.Object);
 
         // Act
         Organisation? result = await sut.GetUserOrganisation("user1", "org2");
@@ -96,6 +113,36 @@ public class DfeHttpSignInApiClientTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Org Two", result!.Name);
+    }
+
+    [Fact]
+    public async Task GetUserOrganisation_ReturnsNull_WhenNotFound()
+    {
+        // Arrange DTOs
+        List<OrganisationDto> organisationDtos = new()
+        {
+            new OrganisationDto { Id = "org1", Name = "Org One" }
+        };
+
+        Mock<IMapper<OrganisationDto, Organisation>> mockMapper = new();
+        mockMapper
+            .Setup(m => m.Map(It.IsAny<OrganisationDto>()))
+            .Returns<OrganisationDto>(dto => new Organisation { Id = dto.Id, Name = dto.Name });
+
+        StubHttpMessageHandler handler = new(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(organisationDtos)
+            });
+
+        HttpClient client = new(handler) { BaseAddress = new Uri("https://fake.local") };
+        DfeHttpSignInApiClient sut = new(client, mockMapper.Object);
+
+        // Act
+        Organisation? result = await sut.GetUserOrganisation("user1", "orgX"); // not present
+
+        // Assert
+        Assert.Null(result);
         Assert.Equal("/users/user1/organisations", handler.CapturedRequests[0].RequestUri!.PathAndQuery);
     }
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Auth/Infrastructure/Mappers/OrganisationDtoToEntityOrganisationTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Auth/Infrastructure/Mappers/OrganisationDtoToEntityOrganisationTests.cs
@@ -1,0 +1,99 @@
+﻿using DfE.GIAP.Web.Features.Auth.Application.Models;
+using DfE.GIAP.Web.Features.Auth.Infrastructure.DataTransferObjects;
+using DfE.GIAP.Web.Features.Auth.Infrastructure.Mappers;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.Auth.Infrastructure.Mappers;
+
+public class OrganisationDtoToEntityOrganisationTests
+{
+    [Fact]
+    public void Map_ThrowsArgumentNullException_WhenInputIsNull()
+    {
+        // Arrange
+        OrganisationDtoToEntityOrganisation mapper = new();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => mapper.Map(null!));
+    }
+
+    [Fact]
+    public void Map_MapsBasicPropertiesCorrectly()
+    {
+        // Arrange
+        OrganisationDtoToEntityOrganisation mapper = new();
+        OrganisationDto dto = new()
+        {
+            Id = "org1",
+            Name = "Test Org",
+            StatutoryLowAge = "5",
+            StatutoryHighAge = "16",
+            EstablishmentNumber = "12345",
+            UniqueReferenceNumber = "URN001",
+            UniqueIdentifier = "UID001",
+            UKProviderReferenceNumber = "UKPRN001"
+        };
+
+        // Act
+        Organisation result = mapper.Map(dto);
+
+        // Assert
+        Assert.Equal("org1", result.Id);
+        Assert.Equal("Test Org", result.Name);
+        Assert.Equal("5", result.StatutoryLowAge);
+        Assert.Equal("16", result.StatutoryHighAge);
+        Assert.Equal("12345", result.EstablishmentNumber);
+        Assert.Equal("URN001", result.UniqueReferenceNumber);
+        Assert.Equal("UID001", result.UniqueIdentifier);
+        Assert.Equal("UKPRN001", result.UKProviderReferenceNumber);
+    }
+
+    [Fact]
+    public void Map_MapsNestedObjectsCorrectly()
+    {
+        // Arrange
+        OrganisationDtoToEntityOrganisation mapper = new();
+        OrganisationDto dto = new()
+        {
+            Id = "org2",
+            Category = new OrganisationCategoryDto { Id = "cat1" },
+            EstablishmentType = new EstablishmentTypeDto { Id = "type1" },
+            LocalAuthority = new LocalAuthorityDto { Code = "LA001" }
+        };
+
+        // Act
+        Organisation result = mapper.Map(dto);
+
+        // Assert
+        Assert.NotNull(result.Category);
+        Assert.Equal("cat1", result.Category!.Id);
+
+        Assert.NotNull(result.EstablishmentType);
+        Assert.Equal("type1", result.EstablishmentType!.Id);
+
+        Assert.NotNull(result.LocalAuthority);
+        Assert.Equal("LA001", result.LocalAuthority!.Code);
+    }
+
+    [Fact]
+    public void Map_AllowsNullNestedObjects()
+    {
+        // Arrange
+        OrganisationDtoToEntityOrganisation mapper = new();
+        OrganisationDto dto = new()
+        {
+            Id = "org3",
+            Category = null,
+            EstablishmentType = null,
+            LocalAuthority = null
+        };
+
+        // Act
+        Organisation result = mapper.Map(dto);
+
+        // Assert
+        Assert.Null(result.Category);
+        Assert.Null(result.EstablishmentType);
+        Assert.Null(result.LocalAuthority);
+    }
+}


### PR DESCRIPTION
## 📌 Summary

This fixes an issue introduced via #407, where LA/MAT/SAT users are unable to retrieve a list of prepared downloads as their identifiers are missing due to a miss-match in property names when deserialisation occurs. 

- splits organisation object into specific dto and entity to allow for mapping.
- creates mapper for organisation
- adds tests over mapper
- updates tests for signin api

## 🔍 Related Issue(s)

<!-- Link to any related issues or tickets -->

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

<!-- Steps to test this PR locally -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots or recordings (e.g. GIFs) to help reviewers -->

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
