### PR TITLE
chore: Update appsettings default page size for FE SearchIndex to 20

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
@@ -83,7 +83,7 @@
             "further-education": {
                 "SearchIndex": "idx-further-education-v3-a",
                 "SearchMode": 0,
-                "Size": 100000,
+                "Size": 20,
                 "IncludeTotalCount": true
             }
         }


### PR DESCRIPTION
## 📌 Summary

Previously SearchFe would limit results to a maximum of 20. This replicates this behaviour than what appears to be the default 100.

#149 

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [x] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
