### PR TITLE
fix: Fix FurtherEducationDto can have nullable PupilPremium and SEN in document

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Downloads/Application/Models/FurtherEducationPupil.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Downloads/Application/Models/FurtherEducationPupil.cs
@@ -8,9 +8,9 @@ public class FurtherEducationPupil
     public string? Gender { get; set; }
     public DateTime DOB { get; set; }
     public string? ConcatenatedName { get; set; }
-    public List<PupilPremiumEntry> PupilPremium { get; set; } = new();
-    public List<SpecialEducationalNeedsEntry> specialEducationalNeeds { get; set; } = new();
+    public List<PupilPremiumEntry>? PupilPremium { get; set; }
+    public List<SpecialEducationalNeedsEntry>? specialEducationalNeeds { get; set; }
 
-    public bool HasPupilPremiumData => PupilPremium.Any();
-    public bool HasSpecialEducationalNeedsData => specialEducationalNeeds.Any();
+    public bool HasPupilPremiumData => PupilPremium?.Any() ?? false;
+    public bool HasSpecialEducationalNeedsData => specialEducationalNeeds?.Any() ?? false;
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Downloads/Infrastructure/Repositories/Mappers/FurtherEducationPupilDtoToEntityMapper .cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Downloads/Infrastructure/Repositories/Mappers/FurtherEducationPupilDtoToEntityMapper .cs
@@ -27,18 +27,18 @@ internal class FurtherEducationPupilDtoToEntityMapper : IMapper<FurtherEducation
             Gender = input.Gender,
             DOB = input.DOB,
             ConcatenatedName = input.ConcatenatedName,
-            PupilPremium = input.PupilPremium.Select(dto => new PupilPremiumEntry
+            PupilPremium = input.PupilPremium?.Select(dto => new PupilPremiumEntry
             {
                 NationalCurriculumYear = dto.NationalCurriculumYear,
                 FullTimeEquivalent = dto.FullTimeEquivalent,
                 AcademicYear = dto.AcademicYear
-            }).ToList(),
-            specialEducationalNeeds = input.specialEducationalNeeds.Select(dto => new SpecialEducationalNeedsEntry
+            }).ToList() ?? [],
+            specialEducationalNeeds = input.specialEducationalNeeds?.Select(dto => new SpecialEducationalNeedsEntry
             {
                 NationalCurriculumYear = dto.NationalCurriculumYear,
                 Provision = dto.Provision,
                 AcademicYear = dto.AcademicYear
-            }).ToList()
+            }).ToList() ?? []
         };
     }
 }


### PR DESCRIPTION
## 📌 Summary

Noticed in test, `Pupil_Premium` can be `null` as can `SEN` so this handles in mapper gracefully.

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
