### PR TITLE
fix: Fix logs to output some invalid identifiers

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/BaseLearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/BaseLearnerNumberController.cs
@@ -387,7 +387,13 @@ namespace DfE.GIAP.Web.Controllers
                 {
                     _logger.LogError(
                         "Some of the LearnerNumber(s) are not valid identifiers: {Identifiers}...",
-                            string.Join(", ", model.Invalid.Take(10)));
+                            string.Join(", ",
+                            model.Invalid
+                                .Take(10)
+                                .Select((invalidUpn) =>
+                                    invalidUpn
+                                        .Replace("\n", string.Empty)
+                                        .Replace("\r", string.Empty))));
                 }
                 //result.Reverse(); // TODO: why is this here?
             }


### PR DESCRIPTION
## 📌 Summary

In prod we'd observed it always logs for EVERY search done, which is a logging bug.

We just want it to log if there are some invalid identifiers, it's not secure data so we'll log some of those identifiers for debugging in production.

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
