### PR TITLE
fix: FeatureGate absent from FeLearnerTextController

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
@@ -26,6 +26,7 @@ using DfE.GIAP.Web.Providers.Session;
 using DfE.GIAP.Web.ViewModels.Search;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement.Mvc;
 using static DfE.GIAP.Web.Controllers.TextBasedSearch.Mappers.LearnerTextSearchResponseToViewModelMapper;
 
 


### PR DESCRIPTION
## 📌 Summary

Previously `BaseLearnerNumberTextController` had this attribute which prevented URL access. It was removed as the controller is not inheriting from the Base anymore for FEText. so this reapplies it.

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [x] CI pass (tests, codecov, lint)
