### PR TITLE
fix: Align FurtherEducation Number+Text GET search routes to redirect to err if unaccessable 

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/FELearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/FELearnerNumberController.cs
@@ -114,7 +114,7 @@ public class FELearnerNumberController : Controller
         _getAvailableDatasetsForPupilsUseCase = getAvailableDatasetsForPupilsUseCase;
     }
 
-    private bool HasAccessToFurtherEducationNumberSearch =>
+    private bool HasAccessToFurtherEducationSearch =>
         User.IsAdmin() ||
             User.IsEstablishmentWithFurtherEducation() ||
                 User.IsEstablishmentWithAccessToULNPages() ||
@@ -124,7 +124,7 @@ public class FELearnerNumberController : Controller
     [HttpGet]
     public async Task<IActionResult> PupilUlnSearch(bool? returnToSearch)
     {
-        if (!HasAccessToFurtherEducationNumberSearch)
+        if (!HasAccessToFurtherEducationSearch)
         {
             return RedirectToAction("Error", "Home");
         }
@@ -142,7 +142,7 @@ public class FELearnerNumberController : Controller
         [FromQuery] string sortDirection,
         bool calledByController = false)
     {
-        if (!HasAccessToFurtherEducationNumberSearch)
+        if (!HasAccessToFurtherEducationSearch)
         {
             return RedirectToAction("Error", "Home");
         }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
@@ -161,7 +161,7 @@ public class FELearnerTextSearchController : Controller
         _getAvailableDatasetsForPupilsUseCase = getAvailableDatasetsForPupilsUseCase;
     }
 
-    private bool HasAccessToFurtherEducationNumberSearch =>
+    private bool HasAccessToFurtherEducationSearch =>
         User.IsAdmin() ||
             User.IsEstablishmentWithFurtherEducation() ||
                 User.IsEstablishmentWithAccessToULNPages() ||
@@ -171,7 +171,7 @@ public class FELearnerTextSearchController : Controller
     [HttpGet]
     public async Task<IActionResult> FurtherEducationNonUlnSearch(bool? returnToSearch)
     {
-        if (!HasAccessToFurtherEducationNumberSearch)
+        if (!HasAccessToFurtherEducationSearch)
         {
             return RedirectToAction("Error", "Home");
         }


### PR DESCRIPTION
## 📌 Summary

As per call with PO

- Allow Admin to see FE search for Text and Number
- Apply same rules for access for FE Text and Number

## 🔍 Related Issue(s)

#426 

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
