### PR TITLE
refactor: Remove Azure AppConfiguration which uses single FurtherEducationFeatureFlag

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Common/Enums/FeatureFlags.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Common/Enums/FeatureFlags.cs
@@ -1,7 +1,0 @@
-﻿namespace DfE.GIAP.Common.Enums
-{
-    public enum FeatureFlags
-    {
-        FurtherEducation
-    }
-}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/FELearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/FELearnerNumberController.cs
@@ -24,12 +24,10 @@ using DfE.GIAP.Web.Helpers.SelectionManager;
 using DfE.GIAP.Web.ViewModels.Search;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement.Mvc;
 using Newtonsoft.Json;
 
 namespace DfE.GIAP.Web.Controllers.LearnerNumber;
 
-[FeatureGate(FeatureFlags.FurtherEducation)]
 [Route(Routes.Application.Search)]
 public class FELearnerNumberController : Controller
 {

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
@@ -26,13 +26,11 @@ using DfE.GIAP.Web.Providers.Session;
 using DfE.GIAP.Web.ViewModels.Search;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement.Mvc;
 using static DfE.GIAP.Web.Controllers.TextBasedSearch.Mappers.LearnerTextSearchResponseToViewModelMapper;
 
 
 namespace DfE.GIAP.Web.Controllers.TextBasedSearch;
 
-[FeatureGate(FeatureFlags.FurtherEducation)]
 [Route(Routes.Application.Search)]
 public class FELearnerTextSearchController : Controller
 {

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/DfE.GIAP.Web.csproj
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/DfE.GIAP.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>d4e9d00c-c90a-4862-a2de-9e169b13be02</UserSecretsId>
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.22" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.14.0" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
   </ItemGroup>

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Extensions/Startup/ServiceCollectionExtensions.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Extensions/Startup/ServiceCollectionExtensions.cs
@@ -26,7 +26,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
-using Microsoft.FeatureManagement;
 
 namespace DfE.GIAP.Web.Extensions.Startup;
 
@@ -39,21 +38,6 @@ public static class ServiceCollectionExtensions
             .Configure<GoogleTagManagerOptions>(configuration.GetSection(GoogleTagManagerOptions.SectionName))
             .Configure<LoggingOptions>(configuration.GetSection(LoggingOptions.SectionName)) // TODO: Move
             .Configure<BlobStorageOptions>(configuration.GetSection(BlobStorageOptions.SectionName)); // TODO: Move
-
-        return services;
-    }
-
-    internal static IServiceCollection AddFeatureFlagConfiguration(this IServiceCollection services, IConfigurationManager configuration)
-    {
-        services.AddFeatureManagement(configuration);
-
-        AzureAppSettings appSettings = configuration.Get<AzureAppSettings>();
-        string connectionUrl = appSettings.FeatureFlagAppConfigUrl;
-        if (!string.IsNullOrWhiteSpace(connectionUrl))
-        {
-            configuration.AddAzureAppConfiguration(options =>
-                options.Connect(connectionUrl).UseFeatureFlags());
-        }
 
         return services;
     }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Program.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Program.cs
@@ -51,9 +51,7 @@ builder.Services
     .AddAllServices()
     .AddWebProviders()
     .AddAuthConfiguration()
-    .AddCookieAndSessionConfiguration()
-    .AddAzureAppConfiguration()
-    .AddFeatureFlagConfiguration(configuration);
+    .AddCookieAndSessionConfiguration();
 
 builder.Services.AddSingleton<IMapper<
     LearnerTextSearchMappingContext, LearnerTextSearchViewModel>,
@@ -103,7 +101,6 @@ if (app.Environment.IsLocal())
 else
 {
     app.UseExceptionHandler("/Home/Exception");
-    app.UseAzureAppConfiguration();
 }
 
 app.UseHsts();

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Views/Shared/Layout/_LayoutHeaderTitlesSearchUln.cshtml
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Views/Shared/Layout/_LayoutHeaderTitlesSearchUln.cshtml
@@ -1,13 +1,13 @@
-﻿<feature name=@FeatureFlags.FurtherEducation>
-    @{
-        var isDfeUser = User.IsDfeUser();
-        if (User.IsOrganisationEstablishmentWithFurtherEducation() || User.IsEstablishmentWithAccessToULNPages() || isDfeUser)
-        {
-            <li class="govuk-service-navigation__item">
-                <a class="govuk-service-navigation__link" asp-controller="FELearnerNumber" asp-action="PupilUlnSearch" id="header--search-uln--link">
-                    Search ULN
-                </a>
-            </li>
-        }
+﻿@{
+    if (User.IsAdmin() ||
+            User.IsOrganisationEstablishmentWithFurtherEducation() ||
+                User.IsEstablishmentWithAccessToULNPages() ||
+                    User.IsDfeUser())
+    {
+        <li class="govuk-service-navigation__item">
+            <a class="govuk-service-navigation__link" asp-controller="FELearnerNumber" asp-action="PupilUlnSearch" id="header--search-uln--link">
+                Search ULN
+            </a>
+        </li>
     }
-</feature>
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Views/_ViewImports.cshtml
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Views/_ViewImports.cshtml
@@ -32,5 +32,4 @@
 @using Microsoft.Extensions.Configuration
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper *, Microsoft.FeatureManagement.AspNetCore
 @addTagHelper *, DfE.GIAP.Web


### PR DESCRIPTION
## 📌 Summary

As per #426 there is a single feature flag in the service "Further Education" that is unused.  It's always turned on.

This removes this feature flag and surrounding package, registrations, so that we can remove these Azure resources, as there doesn't seem to be a need to toggle off FE search.

This will require removal from appsettings and an ADR.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [x] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] CI pass (tests, codecov, lint)
