### PR TITLE
So/release timetable content changes

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Providers/Session/SessionProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Providers/Session/SessionProvider.cs
@@ -13,8 +13,7 @@ public class SessionProvider : ISessionProvider
     }
 
     private ISession Session => _httpContextAccessor.HttpContext?.Session
-        ?? throw new InvalidOperationException(
-            "HttpContext or Session is not available. Make sure session middleware is properly configured.");
+        ?? throw new InvalidOperationException("HttpContext or Session is not available. Make sure session middleware is properly configured.");
 
     public void SetSessionValue(string key, string value)
     {
@@ -29,13 +28,13 @@ public class SessionProvider : ISessionProvider
         Session.SetString(key, json);
     }
 
-    public string GetSessionValue(string key)
+    public string? GetSessionValue(string key)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
         return Session.GetString(key);
     }
 
-    public T GetSessionValueOrDefault<T>(string key)
+    public T? GetSessionValueOrDefault<T>(string key)
     {
         string json = GetSessionValue(key);
         return json == null ? default(T) : JsonSerializer.Deserialize<T>(json);


### PR DESCRIPTION
## 📌 Summary

Changes to the data release timetable content as follows:

As discussed are you able to update the content for the following URL: [Home - Get information about pupils - GOV.UK](https://www.get-information-pupils.service.gov.uk/) when you are back in on Monday?

[@JAMGBADI, Banks](mailto:Banks.JAMGBADI@EDUCATION.GOV.UK), are you able to validate the requested content changes below?

Can you add ticks to the following School census and pupil premium data section
•	2024/25 – Spring Census
•	2024/25 – Summer Census
•	2024/25 – 16-18 disadvantage pupil premium
•	2024/25 – 16-18 SEN

Can you also add the following Attainment section
•	New row add for Year 2024-25
•	Tick added for 2023/24 – Phonics
•	Ticks added for 2024.25 EYFSP and MTC


## 🔍 Related Issue(s)

<!-- Link to any related issues or tickets -->

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ X] other – Please describe: No functional changes, just changes to static presentation model.


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

Visual check of UI.

## 📸 Screenshots (if applicable)

<!-- Add screenshots or recordings (e.g. GIFs) to help reviewers -->

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
