### PR TITLE
feat: MyPupils Add Chained Handlers impl for ChainOfResponsibility

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/ChainedCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/ChainedCommandHandler.cs
@@ -1,0 +1,46 @@
+﻿namespace DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+public sealed class ChainedCommandHandler<TIn> : IChainedCommandHandler<TIn>
+{
+    private ICommandHandler<TIn> _current;
+    private ChainedCommandHandler<TIn>? _next;
+    public ChainedCommandHandler(ICommandHandler<TIn> current)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        _current = current;
+        _next = null;
+    }
+
+    public bool CanHandle(TIn input) => _current.CanHandle(input);
+    public void ChainNext(ICommandHandler<TIn> next)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+
+        if (_next is null)
+        {
+            _next = new ChainedCommandHandler<TIn>(next);
+            return;
+        }
+
+        // Else chain to the next handler
+        _next.ChainNext(next);
+    }
+    public void Handle(TIn input)
+    {
+        // Invoke current if it can handle
+        if (_current.CanHandle(input))
+        {
+            _current.Handle(input);
+            return;
+        }
+
+        // Invoke next if it exists
+        if (_next is not null)
+        {
+            _next.Handle(input);
+            return;
+        }
+
+        // Explicit fail: nobody handled the input
+        throw new InvalidOperationException($"No handler in the chain can handle input of type {typeof(TIn).Name}.");
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/EvaluationHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/EvaluationHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+public sealed class EvaluationHandler<TIn> : IEvaluationHandler<TIn>
+{
+    private readonly ICommandHandler<TIn> _handler;
+
+    public EvaluationHandler(ICommandHandler<TIn> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _handler = handler;
+    }
+    public void Evaluate(TIn input) => _handler.Handle(input);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/IChainedCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/IChainedCommandHandler.cs
@@ -1,0 +1,5 @@
+﻿namespace DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+public interface IChainedCommandHandler<TIn> : ICommandHandler<TIn>
+{
+    void ChainNext(ICommandHandler<TIn> handler);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/ICommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/ICommandHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+public interface ICommandHandler<TIn>
+{
+    bool CanHandle(TIn input);
+    void Handle(TIn input);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/IEvaluationHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Common/CrossCutting/ChainOfResponsibility/CommandHandler/IEvaluationHandler.cs
@@ -1,0 +1,5 @@
+﻿namespace DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+public interface IEvaluationHandler<TIn>
+{
+    void Evaluate(TIn input);
+}


### PR DESCRIPTION
## 📌 Summary

Break off from #276 

Add CoR impl for (n) command handlers to be registers and chained, with no output.

Tests to come in a subsequent PR as currently unused and impl will mature

## 🧪 Changes Made

- [x] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
