### PR TITLE
feat: MyPupils Add PupilSelection handlers

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsFormSelectionModeRequestDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsFormSelectionModeRequestDto.cs
@@ -1,0 +1,8 @@
+﻿namespace DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+public enum MyPupilsFormSelectionModeRequestDto
+{
+    SelectAll,
+    DeselectAll,
+    ManualSelection
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsFormStateRequestDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsFormStateRequestDto.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+public record MyPupilsFormStateRequestDto
+{
+    // TODO consider CustomModelBinding to SelectAllState, which is what should be used in Controller to pass down OR Mapper
+    [FromForm]
+    public bool? SelectAll { get; set; } = null; // Should all pupils be selected
+
+    [FromForm]
+    // TODO Validator for ModelState, Validate XSS, PageNumber fixed size guard
+    public List<string> SelectedPupils { get; set; } = []; // Selected pupils on current page
+
+    // TODO Validator for ModelState, Validate XSS, PageNumber fixed size guard
+    [FromForm]
+    public List<string> CurrentPupils { get; set; } = [];
+
+    public MyPupilsFormSelectionModeRequestDto SelectAllState
+    {
+        get
+        {
+            if (SelectAll.HasValue && SelectAll.Value)
+            {
+                return MyPupilsFormSelectionModeRequestDto.SelectAll;
+            }
+            if (SelectAll.HasValue && !SelectAll.Value)
+            {
+                return MyPupilsFormSelectionModeRequestDto.DeselectAll;
+            }
+            return MyPupilsFormSelectionModeRequestDto.ManualSelection; ;
+        }
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/ClearPupilSelections/ClearMyPupilsPupilSelectionsHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/ClearPupilSelections/ClearMyPupilsPupilSelectionsHandler.cs
@@ -1,0 +1,21 @@
+﻿using DfE.GIAP.Web.Session.Abstraction.Command;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.ClearPupilSelections;
+
+public sealed class ClearMyPupilsPupilSelectionsHandler : IClearMyPupilsPupilSelectionsHandler
+{
+    private readonly ISessionCommandHandler<MyPupilsPupilSelectionState> _sessionCommandHandler;
+
+    public ClearMyPupilsPupilSelectionsHandler(
+        ISessionCommandHandler<MyPupilsPupilSelectionState> sessionCommandHandler)
+    {
+        ArgumentNullException.ThrowIfNull(sessionCommandHandler);
+        _sessionCommandHandler = sessionCommandHandler;
+    }
+
+    public void Handle()
+    {
+        _sessionCommandHandler.StoreInSession(
+            MyPupilsPupilSelectionState.CreateDefault());
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/GetPupilSelections/GetMyPupilsPupilSelectionProvider.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/GetPupilSelections/GetMyPupilsPupilSelectionProvider.cs
@@ -1,0 +1,28 @@
+﻿using DfE.GIAP.Web.Session.Abstraction.Query;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.GetPupilSelections;
+
+internal sealed class GetMyPupilsPupilSelectionProvider : IGetMyPupilsPupilSelectionProvider
+{
+    private readonly ISessionQueryHandler<MyPupilsPupilSelectionState> _selectionStateSessionQueryHandler;
+
+    public GetMyPupilsPupilSelectionProvider(
+        ISessionQueryHandler<MyPupilsPupilSelectionState> selectionStateSessionQueryHandler)
+    {
+        ArgumentNullException.ThrowIfNull(selectionStateSessionQueryHandler);
+        _selectionStateSessionQueryHandler = selectionStateSessionQueryHandler;
+
+    }
+
+    public MyPupilsPupilSelectionState GetPupilSelections()
+    {
+        SessionQueryResponse<MyPupilsPupilSelectionState> selectionStateResponse = _selectionStateSessionQueryHandler.GetSessionObject();
+
+        MyPupilsPupilSelectionState selectionState =
+            selectionStateResponse.HasValue ?
+                selectionStateResponse.Value :
+                    MyPupilsPupilSelectionState.CreateDefault();
+
+        return selectionState;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/IUpdateMyPupilsPupilSelectionsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/IUpdateMyPupilsPupilSelectionsCommandHandler.cs
@@ -1,0 +1,8 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
+
+public interface IUpdateMyPupilsPupilSelectionsCommandHandler
+{
+    void Handle(MyPupilsFormStateRequestDto request);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandler.cs
@@ -1,0 +1,36 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.GetPupilSelections;
+using DfE.GIAP.Web.Session.Abstraction.Command;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
+
+public class UpdateMyPupilsPupilSelectionsCommandHandler : IUpdateMyPupilsPupilSelectionsCommandHandler
+{
+    private readonly IGetMyPupilsPupilSelectionProvider _getPupilSelectionsProvider;
+    private readonly ISessionCommandHandler<MyPupilsPupilSelectionState> _pupilSelectionStateCommandHandler;
+    private readonly IEvaluationHandler<UpdateMyPupilsSelectionStateRequest> _evaluator;
+    public UpdateMyPupilsPupilSelectionsCommandHandler(
+        IGetMyPupilsPupilSelectionProvider getPupilSelectionsProvider,
+        ISessionCommandHandler<MyPupilsPupilSelectionState> pupilSelectionStateCommandHandler,
+        IEvaluationHandler<UpdateMyPupilsSelectionStateRequest> evaluator)
+    {
+        ArgumentNullException.ThrowIfNull(getPupilSelectionsProvider);
+        _getPupilSelectionsProvider = getPupilSelectionsProvider;
+
+        ArgumentNullException.ThrowIfNull(pupilSelectionStateCommandHandler);
+        _pupilSelectionStateCommandHandler = pupilSelectionStateCommandHandler;
+
+        ArgumentNullException.ThrowIfNull(evaluator);
+        _evaluator = evaluator;
+    }
+
+    public void Handle(MyPupilsFormStateRequestDto formDto)
+    {
+        UpdateMyPupilsSelectionStateRequest updateRequest = new(formDto, _getPupilSelectionsProvider.GetPupilSelections());
+
+        _evaluator.Evaluate(updateRequest);
+
+        _pupilSelectionStateCommandHandler.StoreInSession(updateRequest.State);
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsSelectionStateRequest.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsSelectionStateRequest.cs
@@ -1,0 +1,18 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
+
+public record UpdateMyPupilsSelectionStateRequest
+{
+    public UpdateMyPupilsSelectionStateRequest(MyPupilsFormStateRequestDto updateRequest, MyPupilsPupilSelectionState currentState)
+    {
+        ArgumentNullException.ThrowIfNull(updateRequest);
+        UpdateRequest = updateRequest;
+
+        ArgumentNullException.ThrowIfNull(currentState);
+        State = currentState;
+    }
+
+    public MyPupilsFormStateRequestDto UpdateRequest { get; init; }
+    public MyPupilsPupilSelectionState State { get; init; }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/SessionQueryResponse.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Abstraction/Query/SessionQueryResponse.cs
@@ -12,6 +12,6 @@ public record SessionQueryResponse<TValue>
 
     public TValue? Value { get; init; }
     public bool HasValue { get; init; }
-    public static SessionQueryResponse<TValue> NoValue() => new(default(TValue), valueExists: false);
+    public static SessionQueryResponse<TValue> CreateWithNoValue() => new(default(TValue), valueExists: false);
     public static SessionQueryResponse<TValue> Create(TValue value) => new(value, valueExists: true);
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Session/Infrastructure/AspNetCore/Query/AspNetCoreSessionQueryHandler.cs
@@ -32,7 +32,7 @@ public sealed class AspNetCoreSessionQueryHandler<TSessionObject> : ISessionQuer
 
         if (string.IsNullOrWhiteSpace(sessionObjectAccessKey) || !session.TryGetValue(sessionObjectAccessKey, out byte[] _))
         {
-            return SessionQueryResponse<TSessionObject>.NoValue();
+            return SessionQueryResponse<TSessionObject>.CreateWithNoValue();
         }
 
         string sessionValue = session.GetString(sessionObjectAccessKey);

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/ClearPupilSelections/ClearMyPupilsPupilSelectionsHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/ClearPupilSelections/ClearMyPupilsPupilSelectionsHandlerTests.cs
@@ -1,0 +1,41 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.PupilSelection;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.ClearPupilSelections;
+using DfE.GIAP.Web.Session.Abstraction.Command;
+using DfE.GIAP.Web.Tests.TestDoubles.Session;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.MyPupils.PupilSelection.ClearPupilSelections;
+public sealed class ClearMyPupilsPupilSelectionsHandlerTests
+{
+    [Fact]
+    public void Constructor_Throws_When_SessionCommandHandler_Is_Null()
+    {
+        Func<ClearMyPupilsPupilSelectionsHandler> construct = () => new(null!);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Handle_Calls_SessionCommandHandler_With_Default_State()
+    {
+        // Arrange
+        Mock<ISessionCommandHandler<MyPupilsPupilSelectionState>> handlerMock = ISessionCommandHandlerTestDoubles.Default<MyPupilsPupilSelectionState>();
+
+        ClearMyPupilsPupilSelectionsHandler sut = new(handlerMock.Object);
+
+        // Act
+        sut.Handle();
+
+        // Assert
+        MyPupilsPupilSelectionState defaultState = MyPupilsPupilSelectionState.CreateDefault();
+
+        handlerMock.Verify((handler) =>
+            handler.StoreInSession(It.Is<MyPupilsPupilSelectionState>(
+                (t) => t.Mode == defaultState.Mode &&
+                    t.GetManualSelections().SequenceEqual(defaultState.GetManualSelections()) &&
+                        t.GetDeselectedExceptions().SequenceEqual(defaultState.GetDeselectedExceptions()))),
+            Times.Once);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/GetPupilSelections/GetMyPupilsPupilSelectionProviderTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/GetPupilSelections/GetMyPupilsPupilSelectionProviderTests.cs
@@ -1,0 +1,73 @@
+﻿using DfE.GIAP.SharedTests.TestDoubles;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.GetPupilSelections;
+using DfE.GIAP.Web.Session.Abstraction.Query;
+using DfE.GIAP.Web.Tests.TestDoubles.MyPupils;
+using DfE.GIAP.Web.Tests.TestDoubles.Session;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.MyPupils.PupilSelection.GetPupilSelections;
+public sealed class GetMyPupilsPupilSelectionProviderTests
+{
+    [Fact]
+    public void Constructor_Throws_When_PresentationStateHandler_Is_Null()
+    {
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new GetMyPupilsPupilSelectionProvider(null));
+    }
+
+    [Fact]
+    public void GetState_ReturnsDefaultStates_WhenSessionResponsesAreEmpty()
+    {
+        // Arrange
+        SessionQueryResponse<MyPupilsPupilSelectionState> selectionState =
+            SessionQueryResponse<MyPupilsPupilSelectionState>.CreateWithNoValue();
+
+        Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>> selectionStateHandlerMock =
+            ISessionQueryHandlerTestDoubles.MockFor(selectionState);
+
+        GetMyPupilsPupilSelectionProvider sut = new(selectionStateHandlerMock.Object);
+
+        // Act
+        MyPupilsPupilSelectionState result = sut.GetPupilSelections();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equivalent(MyPupilsPupilSelectionState.CreateDefault(), result);
+    }
+
+    [Fact]
+    public void GetState_ReturnsStatesFromSession_WhenAvailable()
+    {
+        // Arrange
+        List<string> upns =
+            UniquePupilNumberTestDoubles.Generate(count: 10)
+                .Select(t => t.Value)
+                .ToList();
+
+        List<string> selectedPupils = upns.Take(5).ToList();
+
+        MyPupilsPupilSelectionState expectedSelectionState =
+            MyPupilsPupilSelectionStateTestDoubles.WithSelectedPupils(
+                SelectionMode.Manual,
+                selected: selectedPupils,
+                deselected: upns.Skip(5).ToList());
+
+        Mock<ISessionQueryHandler<MyPupilsPupilSelectionState>> selectionStateHandler =
+            ISessionQueryHandlerTestDoubles.MockFor(expectedSelectionState);
+
+        GetMyPupilsPupilSelectionProvider sut = new(selectionStateHandler.Object);
+
+        // Act
+        MyPupilsPupilSelectionState response = sut.GetPupilSelections();
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(expectedSelectionState.Mode, response.Mode);
+        Assert.Equal(expectedSelectionState.IsAnyPupilSelected, response.IsAnyPupilSelected);
+        Assert.Equivalent(expectedSelectionState.GetManualSelections(), response.GetManualSelections());
+        Assert.Equivalent(expectedSelectionState.GetDeselectedExceptions(), response.GetDeselectedExceptions());
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandlerTests.cs
@@ -1,0 +1,117 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.GetPupilSelections;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
+using DfE.GIAP.Web.Session.Abstraction.Command;
+using DfE.GIAP.Web.Tests.TestDoubles.Session;
+using Moq;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.MyPupils.PupilSelection.UpdatePupilSelections;
+public sealed class UpdateMyPupilsPupilSelectionsCommandHandlerTests
+{
+    [Fact]
+    public void Constuctor_Throws_When_Provider_Is_Null()
+    {
+        // Arrange
+        Func<UpdateMyPupilsPupilSelectionsCommandHandler> construct =
+            () => new(
+                null!,
+                ISessionCommandHandlerTestDoubles.Default<MyPupilsPupilSelectionState>().Object,
+                new Mock<IEvaluationHandler<UpdateMyPupilsSelectionStateRequest>>().Object);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Constuctor_Throws_When_SessionHandler_Is_Null()
+    {
+        // Arrange
+        Func<UpdateMyPupilsPupilSelectionsCommandHandler> construct =
+            () => new(
+                new Mock<IGetMyPupilsPupilSelectionProvider>().Object,
+                null!,
+                new Mock<IEvaluationHandler<UpdateMyPupilsSelectionStateRequest>>().Object);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Constuctor_Throws_When_EvaluationHandler_Is_Null()
+    {
+        // Arrange
+        Func<UpdateMyPupilsPupilSelectionsCommandHandler> construct =
+            () => new(
+                new Mock<IGetMyPupilsPupilSelectionProvider>().Object,
+                ISessionCommandHandlerTestDoubles.Default<MyPupilsPupilSelectionState>().Object,
+                null!);
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(construct);
+    }
+
+    [Fact]
+    public void Handle_Throws_When_Request_Is_Null()
+    {
+        Mock<IGetMyPupilsPupilSelectionProvider> providerMock = new();
+
+        Mock<ISessionCommandHandler<MyPupilsPupilSelectionState>> selectionStateCommandHandler =
+            ISessionCommandHandlerTestDoubles.Default<MyPupilsPupilSelectionState>();
+
+        Mock<IEvaluationHandler<UpdateMyPupilsSelectionStateRequest>> evaluationHandlerMock = new();
+
+        UpdateMyPupilsPupilSelectionsCommandHandler sut = new(
+            providerMock.Object,
+            selectionStateCommandHandler.Object,
+            evaluationHandlerMock.Object);
+
+        // Act Assert
+        Action act = () => sut.Handle(null!);
+
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void Handle_Calls_Evaluator_And_Calls_SessionHandler()
+    {
+        MyPupilsPupilSelectionState defaultState = MyPupilsPupilSelectionState.CreateDefault();
+
+        Mock<IGetMyPupilsPupilSelectionProvider> providerMock = new();
+        providerMock
+            .Setup(t => t.GetPupilSelections())
+            .Returns(defaultState);
+
+        Mock<ISessionCommandHandler<MyPupilsPupilSelectionState>> selectionStateCommandHandler =
+            ISessionCommandHandlerTestDoubles.Default<MyPupilsPupilSelectionState>();
+
+        Mock<IEvaluationHandler<UpdateMyPupilsSelectionStateRequest>> evaluationHandlerMock = new();
+
+        // Arrange
+        UpdateMyPupilsPupilSelectionsCommandHandler sut = new(
+                providerMock.Object,
+                selectionStateCommandHandler.Object,
+                evaluationHandlerMock.Object);
+
+        MyPupilsFormStateRequestDto request = new();
+
+        // Act
+        sut.Handle(request);
+
+        // Assert
+        providerMock.Verify(t => t.GetPupilSelections(), Times.Once);
+
+        evaluationHandlerMock.Verify((handler)
+            => handler.Evaluate(
+                It.Is<UpdateMyPupilsSelectionStateRequest>(
+                    (req) => ReferenceEquals(request, req.UpdateRequest) && ReferenceEquals(defaultState, req.State))),
+                Times.Once);
+
+        selectionStateCommandHandler.Verify(handler =>
+            handler.StoreInSession(
+                It.Is<MyPupilsPupilSelectionState>((store) => ReferenceEquals(defaultState, store))),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## 📌 Summary

Continue breakoff from #276 

3 operations that handlers impl for adjusting the PupilSelections state object in Web. `Clear`, `Get`, `Update`

## 🧪 Changes Made

- [x] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
