### PR TITLE
feat: MyPupils add mappers for pupil-selection-state and tests

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/Mapper/DataTransferObjects/MyPupilsPupilSelectionStateDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/Mapper/DataTransferObjects/MyPupilsPupilSelectionStateDto.cs
@@ -1,0 +1,15 @@
+﻿namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper.DataTransferObjects;
+
+public record MyPupilsPupilSelectionStateDto
+{
+    // Explicit mode indicator (required to reconstruct the state)
+    public required SelectionMode Mode { get; init; }
+
+    // When Mode == None: holds explicit selections.
+    // When Mode == All : this SHOULD be empty; we use DeselectionExceptions instead.
+    public List<string> ExplicitSelections { get; init; } = [];
+
+    // When Mode == All: holds exceptions (UPNs explicitly deselected).
+    // When Mode == None: this SHOULD be empty.
+    public List<string> DeselectedExceptions { get; init; } = [];
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateFromDtoMapper.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateFromDtoMapper.cs
@@ -1,0 +1,43 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper.DataTransferObjects;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper;
+
+public sealed class MyPupilsPupilSelectionStateFromDtoMapper
+    : IMapper<MyPupilsPupilSelectionStateDto, MyPupilsPupilSelectionState>
+{
+    public MyPupilsPupilSelectionState Map(MyPupilsPupilSelectionStateDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        MyPupilsPupilSelectionState state = MyPupilsPupilSelectionState.CreateDefault();
+
+        SelectionMode mode = dto.Mode;
+
+        switch (mode)
+        {
+            // Select All Mode: All selected EXCEPT explicit deselections
+            case SelectionMode.All:
+
+                state.SelectAll();
+                foreach (string upn in dto.DeselectedExceptions?.Where(t => !string.IsNullOrWhiteSpace(t)) ?? [])
+                {
+                    state.Deselect(upn);
+                }
+
+                break;
+
+            // Manual mode: Explicit selections only.
+            case SelectionMode.Manual:
+            default:
+                foreach (string upn in dto.ExplicitSelections?.Where(t => !string.IsNullOrWhiteSpace(t)) ?? [])
+                {
+                    state.Select(upn);
+                }
+
+                break;
+        }
+
+        return state;
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateToDtoMapper.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateToDtoMapper.cs
@@ -1,0 +1,36 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper.DataTransferObjects;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper;
+
+public sealed class MyPupilsPupilSelectionStateToDtoMapper : IMapper<MyPupilsPupilSelectionState, MyPupilsPupilSelectionStateDto>
+{
+    public MyPupilsPupilSelectionStateDto Map(MyPupilsPupilSelectionState source)
+    {
+#pragma warning disable S3358 // Ternary operators should not be nested
+
+        ArgumentNullException.ThrowIfNull(source);
+
+        // In All mode, we only persist the exceptions.
+        // ExplicitSelections should be empty by design.
+        if (source.Mode == SelectionMode.All)
+        {
+            return new MyPupilsPupilSelectionStateDto
+            {
+                Mode = SelectionMode.All,
+                ExplicitSelections = [],
+                DeselectedExceptions = [.. source.GetDeselectedExceptions()]
+            };
+        }
+
+        // Manual mode: persist explicit selections only.
+        return new MyPupilsPupilSelectionStateDto
+        {
+            Mode = SelectionMode.Manual,
+            ExplicitSelections = [.. source.GetManualSelections()],
+            DeselectedExceptions = []
+        };
+
+#pragma warning restore S3358 // Ternary operators should not be nested
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateFromDtoMapperTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateFromDtoMapperTests.cs
@@ -1,0 +1,114 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.PupilSelection;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper.DataTransferObjects;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.MyPupils.PupilSelection.Mapper;
+public sealed class MyPupilsPupilSelectionStateFromDtoMapperTests
+{
+    [Fact]
+    public void Map_Throws_When_Input_Is_Null()
+    {
+        // Arrange
+        MyPupilsPupilSelectionStateFromDtoMapper sut = new();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => sut.Map(null!));
+    }
+
+    [Fact]
+    public void Map_SelectAllMode_SelectsAllPupils_And_Ignores_Null_DeselectedExceptions()
+    {
+        // Arrange
+        MyPupilsPupilSelectionStateDto dto = new()
+        {
+            Mode = SelectionMode.All,
+            DeselectedExceptions = null
+        };
+
+        MyPupilsPupilSelectionStateFromDtoMapper sut = new();
+
+        // Act
+        MyPupilsPupilSelectionState response = sut.Map(dto);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(SelectionMode.All, response.Mode);
+        Assert.Empty(response.GetManualSelections());
+        Assert.Empty(response.GetDeselectedExceptions());
+    }
+
+    [Fact]
+    public void Map_SelectAllMode_SelectsAllPupils_Except_EmptyOrNull_DeselectedExceptions()
+    {
+        // Arrange
+        MyPupilsPupilSelectionStateDto dto = new()
+        {
+            Mode = SelectionMode.All,
+            DeselectedExceptions = [null, string.Empty, " ", "\n", "a"]
+        };
+
+        MyPupilsPupilSelectionStateFromDtoMapper sut = new();
+
+        // Act
+        MyPupilsPupilSelectionState response = sut.Map(dto);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(SelectionMode.All, response.Mode);
+
+        List<string> expectedDeselections = ["a"];
+        Assert.Empty(response.GetManualSelections());
+        Assert.Equivalent(expectedDeselections, response.GetDeselectedExceptions());
+        Assert.True(response.IsAnyPupilSelected);
+    }
+
+    [Fact]
+    public void Map_ManualSelectMode_Ignores_Null_ExplicitSelections()
+    {
+        // Arrange
+        MyPupilsPupilSelectionStateDto dto = new()
+        {
+            Mode = SelectionMode.Manual,
+            ExplicitSelections = null
+        };
+
+        MyPupilsPupilSelectionStateFromDtoMapper sut = new();
+
+        // Act
+        MyPupilsPupilSelectionState response = sut.Map(dto);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(SelectionMode.Manual, response.Mode);
+
+        Assert.Empty(response.GetManualSelections());
+        Assert.Empty(response.GetDeselectedExceptions());
+        Assert.False(response.IsAnyPupilSelected);
+    }
+
+    [Fact]
+    public void Map_ManualSelectMode_Selects_ManualSelections()
+    {
+        // Arrange
+        MyPupilsPupilSelectionStateDto dto = new()
+        {
+            Mode = SelectionMode.Manual,
+            ExplicitSelections = [null, string.Empty, " ", "\n", "a"]
+        };
+
+        MyPupilsPupilSelectionStateFromDtoMapper sut = new();
+
+        // Act
+        MyPupilsPupilSelectionState response = sut.Map(dto);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(SelectionMode.Manual, response.Mode);
+
+        List<string> selections = ["a"];
+        Assert.Equivalent(selections, response.GetManualSelections());
+        Assert.Empty(response.GetDeselectedExceptions());
+        Assert.True(response.IsAnyPupilSelected);
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateToDtoMapperTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/Mapper/MyPupilsPupilSelectionStateToDtoMapperTests.cs
@@ -1,0 +1,64 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.PupilSelection;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Mapper.DataTransferObjects;
+using DfE.GIAP.Web.Tests.TestDoubles.MyPupils;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.MyPupils.PupilSelection.Mapper;
+public sealed class MyPupilsPupilSelectionStateToDtoMapperTests
+{
+    [Fact]
+    public void Map_Throws_When_Source_Is_Null()
+    {
+        // Arrange
+        MyPupilsPupilSelectionStateToDtoMapper sut = new();
+
+        // Act Assert
+        Assert.Throws<ArgumentNullException>(() => sut.Map(null!));
+    }
+
+    [Fact]
+    public void Map_SelectAllMode_Stores_DeselectedExceptions()
+    {
+        // Arrange
+        List<string> deselectedExceptions = ["c", "d"];
+
+        MyPupilsPupilSelectionState state = MyPupilsPupilSelectionStateTestDoubles.WithSelectedPupils(
+            SelectionMode.All,
+            selected: ["a", "b"],
+            deselected: deselectedExceptions);
+
+        MyPupilsPupilSelectionStateToDtoMapper sut = new();
+
+        // Act
+        MyPupilsPupilSelectionStateDto response = sut.Map(state);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equivalent(deselectedExceptions, response.DeselectedExceptions);
+        Assert.Empty(response.ExplicitSelections);
+    }
+
+    [Fact]
+    public void Map_ManualMode_Stores_ExplicitSelections()
+    {
+        // Arrange
+        List<string> selected = ["a", "b"];
+
+        MyPupilsPupilSelectionState state = MyPupilsPupilSelectionStateTestDoubles.WithSelectedPupils(
+            SelectionMode.Manual,
+            selected: selected,
+            deselected: ["c", "d"]);
+
+        MyPupilsPupilSelectionStateToDtoMapper sut = new();
+
+        // Act
+        MyPupilsPupilSelectionStateDto response = sut.Map(state);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equivalent(selected, response.ExplicitSelections);
+        Assert.Empty(response.DeselectedExceptions);
+
+    }
+}


### PR DESCRIPTION
## 📌 Summary

Continue breakoff from #276 - mapping PupilSelectionState into  DTO for persistance

## 🧪 Changes Made

- [x] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
