### PR TITLE
main: MyPupils UpdatePupilSelections add Handlers predicated on request

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/DeselectAllPupilsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/DeselectAllPupilsCommandHandler.cs
@@ -1,0 +1,16 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections.Handlers;
+
+internal sealed class DeselectAllPupilsCommandHandler : ICommandHandler<UpdateMyPupilsSelectionStateRequest>
+{
+    public bool CanHandle(UpdateMyPupilsSelectionStateRequest input)
+        => input.UpdateRequest.SelectAllState == MyPupilsFormSelectionModeRequestDto.DeselectAll;
+
+    public void Handle(UpdateMyPupilsSelectionStateRequest input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        input.State.DeselectAll();
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/ManualSelectPupilsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/ManualSelectPupilsCommandHandler.cs
@@ -1,0 +1,22 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections.Handlers;
+
+internal sealed class ManualSelectPupilsCommandHandler : ICommandHandler<UpdateMyPupilsSelectionStateRequest>
+{
+    public bool CanHandle(UpdateMyPupilsSelectionStateRequest input) => true;
+    public void Handle(UpdateMyPupilsSelectionStateRequest input)
+    {
+        List<string> selectedPupilsOnPage = input.UpdateRequest.SelectedPupils?.ToList() ?? [];
+        List<string> deselectedPupilsOnPage = input.UpdateRequest.CurrentPupils.Except(selectedPupilsOnPage).ToList();
+
+        foreach (string upn in deselectedPupilsOnPage)
+        {
+            input.State.Deselect(upn);
+        }
+        foreach (string upn in selectedPupilsOnPage)
+        {
+            input.State.Select(upn);
+        }
+    }
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/SelectAllPupilsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/SelectAllPupilsCommandHandler.cs
@@ -1,0 +1,16 @@
+﻿using DfE.GIAP.Core.Common.CrossCutting.ChainOfResponsibility.CommandHandler;
+using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections.Handlers;
+
+internal sealed class SelectAllPupilsCommandHandler : ICommandHandler<UpdateMyPupilsSelectionStateRequest>
+{
+    public bool CanHandle(UpdateMyPupilsSelectionStateRequest input)
+        => input.UpdateRequest.SelectAllState == MyPupilsFormSelectionModeRequestDto.SelectAll;
+
+    public void Handle(UpdateMyPupilsSelectionStateRequest input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        input.State.SelectAll();
+    }
+}


### PR DESCRIPTION
## 📌 Summary

Continue breakoff from #276. There are 3 currently impls that need to apply some form of an update to PupilSelections. "DeselectAll, SelectAll, ManualSelections". 

This brings in those handlers.

They are orchestrated as chained handlers in the CompositionRoot in a future PR.

## 🧪 Changes Made

- [x] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated TODO 
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
