### PR TITLE
fix limited FE records being selected

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/Mappers/LearnerNumericSearchResponseToViewModelMapper.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/Mappers/LearnerNumericSearchResponseToViewModelMapper.cs
@@ -35,8 +35,7 @@ public sealed class LearnerNumericSearchResponseToViewModelMapper :
                 .Select(_furtherEducationLearnerToViewModelMapper.Map)
                 .ToList() ?? [];
 
-        // Apply PageSize limit
-        input.Model.Learners = learners.Take(input.Model.PageSize);
+        input.Model.Learners = learners;
 
         // Populate meta-data fields for pagination and UI messaging.
         input.Model.Total = input.Response.TotalNumberOfResults;


### PR DESCRIPTION
## 📌 Summary

Currently if a user enters more than 20 ULNs for FE number search, it only selects the initial 20. This causes issues when trying to download all of the records as only the initial 20 are selected.

- remove additional check which limits the mapped learners to the page size. This allows the original user input to be passed into the selection manager later. A short term solution. 

## 🔍 Related Issue(s)

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## 📝 Description

<!-- Detailed description of what was changed and why -->

## 🧪 How to Test

<!-- Steps to test this PR locally -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots or recordings (e.g. GIFs) to help reviewers -->

## ✅ Checklist
- [ ] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [ ] CI pass (tests, codecov, lint)
