### PR TITLE
Fix: MyPupils when end of list can go back

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Views/MyPupilList/Index.cshtml
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Views/MyPupilList/Index.cshtml
@@ -120,6 +120,37 @@
                         <span>@noPupilsMessage</span>
                     </strong>
                 </div>
+                <ul class="pagination-list">
+                    <!-- [Previous] -->
+                    @if (Model.PageNumber > 1)
+                    {
+                        <li class="page-list-previous">
+                            <button asp-controller="@Model.UpdateFormController"
+                                    asp-action="@Model.UpdateFormAction"
+                                    asp-route-pageNumber="@(Model.PageNumber - 1)"
+                                    asp-route-sortField="@Model.SortField"
+                                    asp-route-sortDirection="@Model.SortDirection"
+                                    id="page-previous"
+                                    type="submit">
+                                &#60;&#60; Previous
+                            </button>
+                        </li>
+                        <!-- [1] -->
+                        <li class="page-list-first">
+                            <button asp-controller="@Model.UpdateFormController"
+                                    asp-action="@Model.UpdateFormAction"
+                                    asp-route-pageNumber="1"
+                                    asp-route-sortField="@Model.SortField"
+                                    asp-route-sortDirection="@Model.SortDirection"
+                                    id="page-first"
+                                    type="submit">
+                                1
+                            </button>
+                        </li>
+                        <!-- [current] -->
+                        <li>@Model.PageNumber</li>
+                    }
+                </ul>
             }
             else
             {


### PR DESCRIPTION
## 📌 Summary

Fixes where user has hit the end of a list with no pupils, and can traverse back or to the start

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
