### PR TITLE
tests: ClaimsPrincipalFake adjust to static class

### DIFF
--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Admin/AdminControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Admin/AdminControllerTests.cs
@@ -22,9 +22,8 @@ using Xunit;
 namespace DfE.GIAP.Web.Tests.Controllers.Admin;
 
 [Trait("Category", "Admin Controller Unit Tests")]
-public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake>
+public sealed class AdminControllerTests
 {
-    private readonly UserClaimsPrincipalFake _userClaimsPrincipalFake;
     private readonly ISecurityService _securityService = Substitute.For<ISecurityService>();
     private readonly ISessionProvider _sessionProvider = Substitute.For<ISessionProvider>();
 
@@ -36,11 +35,6 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
 
     private readonly IDownloadSecurityReportDetailedSearchesService _downloadSecurityReportDetailedSearchesService =
         Substitute.For<IDownloadSecurityReportDetailedSearchesService>();
-
-    public AdminControllerTests(UserClaimsPrincipalFake userClaimsPrincipalFake)
-    {
-        _userClaimsPrincipalFake = userClaimsPrincipalFake;
-    }
 
     private AdminController GetAdminController()
     {
@@ -55,7 +49,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_AdminViewLoadsSuccessfully()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -76,7 +70,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_DashboardOptions_Returns_ManageDocuments_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -102,7 +96,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_DashboardOptions_Returns_SecurityReportsByUpnUln_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -128,7 +122,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_DashboardOptions_Returns_SecurityReportsForYourOrganisation_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -154,7 +148,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_DashboardOptions_Returns_DownloadSecurityReportsBySchool_Admin_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -180,7 +174,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_DashboardOptions_Returns_DownloadSecurityReportsBySchool_NonAdmin_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -206,7 +200,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_DashboardOptions_Returns_ValidationMessage_If_No_Selection_Made()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -235,7 +229,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SchoolCollegeDownloadOptionsAdminGet_Renders_Correct_View()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -256,7 +250,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SchoolCollegeDownloadOptions_SecurityReportsBySchool_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -282,7 +276,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SchoolCollegeDownloadOptions_Returns_Validation_Message_If_No_Selection_Made()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -309,7 +303,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsBySchoolGet_Renders_Correct_View()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -330,7 +324,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsBySchoolEstablishmentSelectionGet_Renders_Correct_View()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -351,7 +345,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SecurityReportsBySchoolConfirmationGet_Renders_Correct_View()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -372,7 +366,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SecurityReportsForYourOrganisationGet_Renders_Correct_View()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -393,7 +387,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsBySchoolPost_Adds_ModelError_If_Neither_LA_or_AT_Selected()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -420,7 +414,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchoolPost_Adds_ModelError_If_Neither_LA_or_AT_Selected_And_No_Establishment()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -448,7 +442,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchoolPost_Adds_ModelError_If_Both_LA_and_AT_Selected_And_No_Establishment()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -478,7 +472,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchoolPost_Sets_Correct_Model_Properties_If_No_Establishment()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -510,7 +504,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchoolPost_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
         ControllerContext context = new()
@@ -566,7 +560,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadLoginDetailsSecurityReportsBySchool_By_UniqueReferenceNumber_Post_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -623,7 +617,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchool_By_SATApprover_Post_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetSATApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetSATApproverClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -681,7 +675,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchool_DetailedSearches_By_UniqueReferenceNumber_Post_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -738,7 +732,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_DownloadSecurityReportsBySchool_DetailedSearches_By_SATApprover_Post_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetSATApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetSATApproverClaimsPrincipal();
 
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
@@ -795,7 +789,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -840,7 +834,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_Correct_Data_For_SAT_Approver()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetSATApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetSATApproverClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -898,7 +892,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_Correct_Data_For_LA_Approver()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetLAApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetLAApproverClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -955,7 +949,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_Correct_Data_For_FE_Approver()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetFEApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetFEApproverClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -1012,7 +1006,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_Correct_Data_For_Organisation_User()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -1070,7 +1064,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_LoginDetails_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -1117,7 +1111,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_NoContent_if_no_data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -1155,7 +1149,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_GetSecurityReport_Returns_NoContent_if_report_type_invalid()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -1193,7 +1187,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SecurityReportsBySchoolConfirmationPost_Returns_Establishment_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -1219,7 +1213,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SecurityReportsBySchoolConfirmationPost_Returns_School_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -1245,7 +1239,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SecurityReportsBySchoolConfirmationPost_Returns_Dashboard_Redirect_To_Action()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -1271,7 +1265,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public void AdminController_SecurityReportsBySchoolConfirmationPost_Returns_Validation_Message_If_No_Option_Selected()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new()
         {
             HttpContext = new DefaultHttpContext() { User = user }
@@ -1300,7 +1294,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsForYourOrganisation_DetailedSearches_Post_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("0");
         ControllerContext context = new()
@@ -1349,7 +1343,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsForYourOrganisation_LoginDetails_Post_Returns_Correct_Data()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("1");
         ControllerContext context = new()
@@ -1398,7 +1392,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsForYourOrganisation_DetailedSearches_Post_Returns_Validation_Message_If_DocumentID_Is_Null()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
 
@@ -1445,7 +1439,7 @@ public sealed class AdminControllerTests : IClassFixture<UserClaimsPrincipalFake
     public async Task AdminController_SecurityReportsForYourOrganisation_DetailedSearches_Post_Returns_Validation_Message_If_DocumentID_Is_Invalid()
     {
         // Arrange
-        ClaimsPrincipal user = _userClaimsPrincipalFake.GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         Mock<ISession> mockSession = new();
         mockSession.Setup(x => x.Id).Returns("12345");
         ControllerContext context = new()

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Admin/SecurityReports/SecurityReportByPupilStudentRecordControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Admin/SecurityReports/SecurityReportByPupilStudentRecordControllerTests.cs
@@ -56,7 +56,7 @@ namespace DfE.GIAP.Web.Tests.Controllers.Admin.SecurityReports
         public async Task SecurityReportByPupilStudentRecordController_DownloadSecurityReportByUpnUln_Successfully_downloads_CSV_file_when_valid_UPN_entered()
         {
             // Arrange
-            var user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+            var user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
             var azureAppSettings = new AzureAppSettings() { IsSessionIdStoredInCookie = false };
             var fakeAppSettings = new Mock<IOptions<AzureAppSettings>>();
             fakeAppSettings.SetupGet(x => x.Value).Returns(azureAppSettings);
@@ -94,7 +94,7 @@ namespace DfE.GIAP.Web.Tests.Controllers.Admin.SecurityReports
         public async Task SecurityReportByPupilStudentRecordController_DownloadSecurityReportByUpnUln_Successfully_downloads_CSV_file_when_valid_ULN_entered()
         {
             // Arrange
-            var user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+            var user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
             var azureAppSettings = new AzureAppSettings() { IsSessionIdStoredInCookie = false };
             var fakeAppSettings = new Mock<IOptions<AzureAppSettings>>();
             fakeAppSettings.SetupGet(x => x.Value).Returns(azureAppSettings);
@@ -132,7 +132,7 @@ namespace DfE.GIAP.Web.Tests.Controllers.Admin.SecurityReports
         public async Task SecurityReportByPupilStudentRecordController_DownloadSecurityReportByUpnUln_Adds_ModelError_If_No_UPN_Or_ULN_Entered()
         {
             // Arrange
-            var user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+            var user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
             var azureAppSettings = new AzureAppSettings() { IsSessionIdStoredInCookie = false };
             var fakeAppSettings = new Mock<IOptions<AzureAppSettings>>();
             fakeAppSettings.SetupGet(x => x.Value).Returns(azureAppSettings);
@@ -158,7 +158,7 @@ namespace DfE.GIAP.Web.Tests.Controllers.Admin.SecurityReports
         public async Task SecurityReportByPupilStudentRecordController_DownloadSecurityReportByUpnUln_Adds_ModelError_If_No_Results_Found()
         {
             // Arrange
-            var user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+            var user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
             var azureAppSettings = new AzureAppSettings() { IsSessionIdStoredInCookie = false };
             var fakeAppSettings = new Mock<IOptions<AzureAppSettings>>();
             fakeAppSettings.SetupGet(x => x.Value).Returns(azureAppSettings);

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/AuthenticationControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/AuthenticationControllerTests.cs
@@ -14,7 +14,7 @@ namespace DfE.GIAP.Web.Tests.Controllers;
 
 [Trait("Category", "Authentication Controller Unit Tests")]
 
-public sealed class AuthenticationControllerTests : IClassFixture<UserClaimsPrincipalFake>
+public sealed class AuthenticationControllerTests
 {
     private readonly Mock<IOptions<DsiOptions>> _mockAzureAppSettings = new();
 
@@ -69,7 +69,7 @@ public sealed class AuthenticationControllerTests : IClassFixture<UserClaimsPrin
     public void AuthenticationController_LoginDSI_Redirect_If_Authenticated()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         ControllerContext context = new() { HttpContext = new DefaultHttpContext() { User = user, Session = new SessionFake() } };
         AuthenticationController controller = GetAuthenticationController();
         controller.ControllerContext = context;
@@ -88,7 +88,7 @@ public sealed class AuthenticationControllerTests : IClassFixture<UserClaimsPrin
     public async Task AuthenticationController_SignoutDSI_And_Redirect()
     {
         // Arrange
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
 
         Mock<IAuthenticationService> authServiceMock = new();
         authServiceMock

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Extensions/ControllerTestExtensions.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Extensions/ControllerTestExtensions.cs
@@ -11,7 +11,7 @@ internal static class ControllerTestExtensions
     internal static HttpContext StubHttpContext<T>(this T controller) where T : ControllerBase
     {
         // TODO may want control of this principal on the context?
-        ClaimsPrincipal claimsPrincipal = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        ClaimsPrincipal claimsPrincipal = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
 
         DefaultHttpContext httpContext = new()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/PreparedDownloads/PreparedDownloadsControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/PreparedDownloads/PreparedDownloadsControllerTests.cs
@@ -48,7 +48,7 @@ public class PreparedDownloadsControllerTests
             mockEventLogger.Object);
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = HttpContextTestDoubles.WithUser(new UserClaimsPrincipalFake().GetLAUserClaimsPrincipal())
+            HttpContext = HttpContextTestDoubles.WithUser(UserClaimsPrincipalFake.GetLAUserClaimsPrincipal())
         };
 
         // Act
@@ -89,7 +89,7 @@ public class PreparedDownloadsControllerTests
 
         controller.ControllerContext = new ControllerContext
         {
-            HttpContext = HttpContextTestDoubles.WithUser(new UserClaimsPrincipalFake().GetLAUserClaimsPrincipal())
+            HttpContext = HttpContextTestDoubles.WithUser(UserClaimsPrincipalFake.GetLAUserClaimsPrincipal())
         };
 
         // Act

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/FELearnerNumberControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/FELearnerNumberControllerTests.cs
@@ -37,6 +37,7 @@ using Moq;
 using Newtonsoft.Json;
 using NSubstitute;
 using Xunit;
+using System.Security.Claims;
 
 namespace DfE.GIAP.Web.Tests.Controllers.Search.LearnerNumber;
 
@@ -113,7 +114,7 @@ public class FELearnerNumberControllerTests : IClassFixture<PaginatedResultsFake
 
         // act
         var sut = GetController();
-        sut.ControllerContext.HttpContext.User = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        sut.ControllerContext.HttpContext.User = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
         var result = await sut.PupilUlnSearch(null);
 
         // assert
@@ -142,7 +143,7 @@ public class FELearnerNumberControllerTests : IClassFixture<PaginatedResultsFake
 
         // act
         var sut = GetController();
-        sut.ControllerContext.HttpContext.User = new UserClaimsPrincipalFake().GetSpecificUserClaimsPrincipal(
+        sut.ControllerContext.HttpContext.User = UserClaimsPrincipalFake.GetSpecificUserClaimsPrincipal(
              DsiKeys.OrganisationCategory.Establishment,
              DsiKeys.EstablishmentType.CommunitySchool, //not relevant for this test
              AuthRoles.Approver,
@@ -176,7 +177,7 @@ public class FELearnerNumberControllerTests : IClassFixture<PaginatedResultsFake
 
         // act
         var sut = GetController();
-        sut.ControllerContext.HttpContext.User = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        sut.ControllerContext.HttpContext.User = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
         var result = await sut.PupilUlnSearch(null);
 
         // assert
@@ -1876,7 +1877,7 @@ public class FELearnerNumberControllerTests : IClassFixture<PaginatedResultsFake
 
     private FELearnerNumberController GetController()
     {
-        var user = new UserClaimsPrincipalFake().GetFEApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetFEApproverClaimsPrincipal();
 
         _mockAppSettings = new AzureAppSettings()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/NPDLearnerNumberSearchControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/NPDLearnerNumberSearchControllerTests.cs
@@ -2188,7 +2188,7 @@ public class NPDLearnerNumberSearchControllerTests : IClassFixture<PaginatedResu
 
     private NPDLearnerNumberSearchController GetController(int commonTransferFileUPNLimit = 4000)
     {
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
 
         _mockAppSettings = new AzureAppSettings()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/PupilPremiumLearnerNumberControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/PupilPremiumLearnerNumberControllerTests.cs
@@ -1828,7 +1828,7 @@ public class PupilPremiumLearnerNumberControllerTests : IClassFixture<PaginatedR
 
     private PupilPremiumLearnerNumberController GetController()
     {
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
 
         _mockAppSettings = new AzureAppSettings()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/TextBasedSearch/FELearnerTextSearchControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/TextBasedSearch/FELearnerTextSearchControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using DfE.GIAP.Common.AppSettings;
+﻿using System.Security.Claims;
+using DfE.GIAP.Common.AppSettings;
 using DfE.GIAP.Common.Constants;
 using DfE.GIAP.Common.Enums;
 using DfE.GIAP.Common.Models.Common;
@@ -1442,7 +1443,7 @@ public class FELearnerTextSearchControllerTests : IClassFixture<PaginatedResults
 
     private FELearnerTextSearchController GetController()
     {
-        var user = new UserClaimsPrincipalFake().GetFEApproverClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetFEApproverClaimsPrincipal();
 
         _mockAppSettings = new AzureAppSettings()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/TextBasedSearch/NPDLearnerTextSearchControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/TextBasedSearch/NPDLearnerTextSearchControllerTests.cs
@@ -210,7 +210,7 @@ public class NPDLearnerTextSearchControllerTests : IClassFixture<PaginatedResult
         // Arrange
         NPDLearnerTextSearchController sut = GetController();
         //override default user to make admin so Ids are not masked, not testing rbac rules for this test
-        sut.ControllerContext.HttpContext.User = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        sut.ControllerContext.HttpContext.User = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
 
 
         _mockSession.SetString(sut.SearchSessionKey, _paginatedResultsFake.GetUpns());
@@ -1721,7 +1721,7 @@ public class NPDLearnerTextSearchControllerTests : IClassFixture<PaginatedResult
 
     private NPDLearnerTextSearchController GetController()
     {
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
 
         _mockAppSettings = new AzureAppSettings()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/TextBasedSearch/PPLearnerTextSearchControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/TextBasedSearch/PPLearnerTextSearchControllerTests.cs
@@ -169,7 +169,7 @@ public class PPLearnerTextSearchControllerTests : IClassFixture<PaginatedResults
 
         PPLearnerTextSearchController sut = GetController();
         //override default user to make admin so Ids are not masked, not testing rbac rules for this test
-        sut.ControllerContext.HttpContext.User = new UserClaimsPrincipalFake().GetAdminUserClaimsPrincipal();
+        sut.ControllerContext.HttpContext.User = UserClaimsPrincipalFake.GetAdminUserClaimsPrincipal();
 
         _mockSession.SetString(sut.SearchSessionKey, _paginatedResultsFake.GetUpns());
 
@@ -1514,7 +1514,7 @@ public class PPLearnerTextSearchControllerTests : IClassFixture<PaginatedResults
 
     private PPLearnerTextSearchController GetController(int maxMPLLimit = 4000)
     {
-        ClaimsPrincipal user = new UserClaimsPrincipalFake().GetUserClaimsPrincipal();
+        ClaimsPrincipal user = UserClaimsPrincipalFake.GetUserClaimsPrincipal();
 
         _mockAppSettings = new AzureAppSettings()
         {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Logging/BusinessEventFactoryTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Logging/BusinessEventFactoryTests.cs
@@ -44,7 +44,7 @@ public class BusinessEventFactoryTests
     public void CreateSearch_Returns_Model_With_PassedInData()
     {
         // Arrange
-        HttpContext httpContext = HttpContextTestDoubles.WithUser(new UserClaimsPrincipalFake().GetLAUserClaimsPrincipal());
+        HttpContext httpContext = HttpContextTestDoubles.WithUser(UserClaimsPrincipalFake.GetLAUserClaimsPrincipal());
         _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext);
 
         Dictionary<string, bool> filterFlags = new() { { "flag1", true } };
@@ -61,7 +61,7 @@ public class BusinessEventFactoryTests
     public void CreateDownload_Returns_Model_With_PassedInData()
     {
         // Arrange
-        HttpContext httpContext = HttpContextTestDoubles.WithUser(new UserClaimsPrincipalFake().GetLAUserClaimsPrincipal());
+        HttpContext httpContext = HttpContextTestDoubles.WithUser(UserClaimsPrincipalFake.GetLAUserClaimsPrincipal());
         _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext);
 
         Dataset dataset = Dataset.KS1;

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Helpers/SearchDownloadHelperTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Helpers/SearchDownloadHelperTests.cs
@@ -545,7 +545,7 @@ public class SearchDownloadHelperTests
                 false => isMAT ? DsiKeys.OrganisationCategory.MultiAcademyTrust : DsiKeys.OrganisationCategory.Establishment
             };
 
-            var user = new UserClaimsPrincipalFake().GetSpecificUserClaimsPrincipal(
+            var user = UserClaimsPrincipalFake.GetSpecificUserClaimsPrincipal(
                 organisationId,
                 DsiKeys.EstablishmentType.CommunitySchool, // irrelevant for this test..
                 role,

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Middleware/ConsentRedirectMiddlewareTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Middleware/ConsentRedirectMiddlewareTests.cs
@@ -18,7 +18,7 @@ public class ConsentRedirectMiddlewareTests
         // Arrange
         HttpContext context = CreateContext(true);
         ISessionProvider sessionProvider = Substitute.For<ISessionProvider>();
-        sessionProvider.GetSessionValue(SessionKeys.ConsentGivenKey).Returns((string)null);
+        sessionProvider.GetSessionValue(SessionKeys.ConsentGivenKey).Returns((string)null!);
         ConsentRedirectMiddleware middleware = CreateMiddleware();
 
         // Act
@@ -86,12 +86,14 @@ public class ConsentRedirectMiddlewareTests
         Assert.DoesNotContain(Routes.Application.Consent, context.Response.Headers["location"].ToString());
     }
 
-    private HttpContext CreateContext(bool isAuthenticated)
+    private static HttpContext CreateContext(bool isAuthenticated)
     {
-        ClaimsPrincipal userPrincipal = new(new ClaimsIdentity(new Claim[0], isAuthenticated ? "fake" : null));
-        HttpContext context = new DefaultHttpContext();
-        context.Session = new SessionFake();
-        context.User = userPrincipal;
+        ClaimsPrincipal userPrincipal = new(new ClaimsIdentity(Array.Empty<Claim>(), isAuthenticated ? "fake" : null));
+        DefaultHttpContext context = new()
+        {
+            Session = new SessionFake(),
+            User = userPrincipal
+        };
         return context;
     }
 

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/UserClaimsPrincipalFake.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/TestDoubles/UserClaimsPrincipalFake.cs
@@ -1,209 +1,208 @@
 ﻿using DfE.GIAP.Web.Features.Auth.Application.Claims;
 using System.Security.Claims;
 
-namespace DfE.GIAP.Web.Tests.TestDoubles
+namespace DfE.GIAP.Web.Tests.TestDoubles;
+
+public static class UserClaimsPrincipalFake
 {
-    public class UserClaimsPrincipalFake
+    public static ClaimsPrincipal GetUserClaimsPrincipal()
     {
-        public ClaimsPrincipal GetUserClaimsPrincipal()
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email, "discoverytest842@gmail.com"),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim("custom-claim", "example claim value"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Test Org"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId,"001"),
-                new Claim(AuthClaimTypes.OrganisationEstablishmentTypeId, "00"),
-                new Claim(AuthClaimTypes.OrganisationHighAge, "13"),
-                new Claim(AuthClaimTypes.OrganisationLowAge, "2"),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432")
-            }, "mock"));
+            new(ClaimTypes.Email, "discoverytest842@gmail.com"),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new("custom-claim", "example claim value"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Test Org"),
+            new(AuthClaimTypes.OrganisationCategoryId,"001"),
+            new(AuthClaimTypes.OrganisationEstablishmentTypeId, "00"),
+            new(AuthClaimTypes.OrganisationHighAge, "13"),
+            new(AuthClaimTypes.OrganisationLowAge, "2"),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432")
+        }, "mock"));
 
-            return user;
-        }
+        return user;
+    }
 
-        public ClaimsPrincipal GetLAApproverClaimsPrincipal()
+    public static ClaimsPrincipal GetLAApproverClaimsPrincipal()
+    {
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email, "discoverytest842+LAApprover@gmail.com"),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Test Org"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId,"002"),
-                new Claim(AuthClaimTypes.OrganisationHighAge, "20"),
-                new Claim(AuthClaimTypes.OrganisationLowAge, "2"),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
-                new Claim(ClaimTypes.Role,"GIAPApprover")
-            }, "mock"));
+            new(ClaimTypes.Email, "discoverytest842+LAApprover@gmail.com"),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Test Org"),
+            new(AuthClaimTypes.OrganisationCategoryId,"002"),
+            new(AuthClaimTypes.OrganisationHighAge, "20"),
+            new(AuthClaimTypes.OrganisationLowAge, "2"),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
+            new(ClaimTypes.Role,"GIAPApprover")
+        }, "mock"));
 
-            return user;
-        }
+        return user;
+    }
 
-        public ClaimsPrincipal GetSATApproverClaimsPrincipal()
+    public static ClaimsPrincipal GetSATApproverClaimsPrincipal()
+    {
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email, "discoverytest842+SATApprover@gmail.com"),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim("custom-claim", "example claim value"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Test Org"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId,"013"),
-                new Claim(AuthClaimTypes.OrganisationHighAge, "20"),
-                new Claim(AuthClaimTypes.OrganisationLowAge, "2"),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
-                new Claim(ClaimTypes.Role,"GIAPApprover")
-            }, "mock"));
+            new(ClaimTypes.Email, "discoverytest842+SATApprover@gmail.com"),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new("custom-claim", "example claim value"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Test Org"),
+            new(AuthClaimTypes.OrganisationCategoryId,"013"),
+            new(AuthClaimTypes.OrganisationHighAge, "20"),
+            new(AuthClaimTypes.OrganisationLowAge, "2"),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
+            new(ClaimTypes.Role,"GIAPApprover")
+        }, "mock"));
 
-            return user;
-        }
+        return user;
+    }
 
-        public ClaimsPrincipal GetAdminUserClaimsPrincipal()
+    public static ClaimsPrincipal GetAdminUserClaimsPrincipal()
+    {
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email,"discoverytest842+ADMIN@gmail.com"),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim("custom-claim", "example claim value"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Department for Education"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId,"789"),
-                new Claim(AuthClaimTypes.OrganisationHighAge, "20"),
-                new Claim(AuthClaimTypes.OrganisationLowAge, "2"),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
-                new Claim(ClaimTypes.Role,"GIAPAdmin")
-            }, "mock"));
+            new(ClaimTypes.Email,"discoverytest842+ADMIN@gmail.com"),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new("custom-claim", "example claim value"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Department for Education"),
+            new(AuthClaimTypes.OrganisationCategoryId,"789"),
+            new(AuthClaimTypes.OrganisationHighAge, "20"),
+            new(AuthClaimTypes.OrganisationLowAge, "2"),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
+            new(ClaimTypes.Role,"GIAPAdmin")
+        }, "mock"));
 
-            return user;
-        }
+        return user;
+    }
 
-        public ClaimsPrincipal GetFEApproverClaimsPrincipal()
+    public static ClaimsPrincipal GetFEApproverClaimsPrincipal()
+    {
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email,"discoverytest842+FEApprover@gmail.com"),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Test Org"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId, "001"),
-                new Claim(AuthClaimTypes.OrganisationEstablishmentTypeId, "18"),
-                new Claim(AuthClaimTypes.OrganisationHighAge, "20"),
-                new Claim(AuthClaimTypes.OrganisationLowAge, "2"),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
-                new Claim(ClaimTypes.Role,"GIAPApprover")
-            }, "mock"));
+            new(ClaimTypes.Email,"discoverytest842+FEApprover@gmail.com"),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Test Org"),
+            new(AuthClaimTypes.OrganisationCategoryId, "001"),
+            new(AuthClaimTypes.OrganisationEstablishmentTypeId, "18"),
+            new(AuthClaimTypes.OrganisationHighAge, "20"),
+            new(AuthClaimTypes.OrganisationLowAge, "2"),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
+            new(ClaimTypes.Role,"GIAPApprover")
+        }, "mock"));
 
-            return user;
-        }
+        return user;
+    }
 
-        public ClaimsPrincipal GetLAUserClaimsPrincipal()
+    public static ClaimsPrincipal GetLAUserClaimsPrincipal()
+    {
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email,"discoverytest842+LAApprover@gmail.com"),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Test Org"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId, "002"),
-                new Claim(AuthClaimTypes.OrganisationEstablishmentTypeId, "18"),
-                new Claim(AuthClaimTypes.OrganisationHighAge, "20"),
-                new Claim(AuthClaimTypes.OrganisationLowAge, "2"),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
-                new Claim(ClaimTypes.Role,"GIAPApprover")
-            }, "mock"));
+            new(ClaimTypes.Email,"discoverytest842+LAApprover@gmail.com"),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Test Org"),
+            new(AuthClaimTypes.OrganisationCategoryId, "002"),
+            new(AuthClaimTypes.OrganisationEstablishmentTypeId, "18"),
+            new(AuthClaimTypes.OrganisationHighAge, "20"),
+            new(AuthClaimTypes.OrganisationLowAge, "2"),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
+            new(ClaimTypes.Role,"GIAPApprover")
+        }, "mock"));
 
-            return user;
-        }
+        return user;
+    }
 
-        public ClaimsPrincipal GetSpecificUserClaimsPrincipal(
-            string organisationCategoryId,
-            string organisationEstablishmentType,
-            string role,
-            int organisationLowAge,
-            int organisationHighAge,
-            string email = "testy.mctester@somewhere.net")
+    public static ClaimsPrincipal GetSpecificUserClaimsPrincipal(
+        string organisationCategoryId,
+        string organisationEstablishmentType,
+        string role,
+        int organisationLowAge,
+        int organisationHighAge,
+        string email = "testy.mctester@somewhere.net")
+    {
+        ClaimsPrincipal user = new(new ClaimsIdentity(new Claim[]
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.Email, email),
-                new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
-                new Claim(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
-                new Claim(ClaimTypes.Email,"test@yahoo.com"),
-                new Claim(ClaimTypes.GivenName,"Abc"),
-                new Claim(ClaimTypes.Surname,"xyz"),
-                new Claim(AuthClaimTypes.OrganisationId, "123"),
-                new Claim(AuthClaimTypes.OrganisationName, "Test Org"),
-                new Claim(AuthClaimTypes.OrganisationCategoryId, organisationCategoryId),
-                new Claim(AuthClaimTypes.OrganisationEstablishmentTypeId, organisationEstablishmentType),
-                new Claim(AuthClaimTypes.OrganisationHighAge, organisationHighAge.ToString()),
-                new Claim(AuthClaimTypes.OrganisationLowAge, organisationLowAge.ToString()),
-                new Claim(AuthClaimTypes.EstablishmentNumber,"89"),
-                new Claim(AuthClaimTypes.LocalAuthorityNumber,"98"),
-                new Claim(AuthClaimTypes.UniqueReferenceNumber,"121"),
-                new Claim(AuthClaimTypes.UniqueIdentifier,"007"),
-                new Claim(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
-                new Claim(ClaimTypes.Role, role)
-            }, "mock"));
+            new(ClaimTypes.Email, email),
+            new(ClaimTypes.NameIdentifier, "1"),
+            new(AuthClaimTypes.UserId, "00000000-0000-0000-0000-000000000000"),
+            new(AuthClaimTypes.SessionId, "8cd6f4a2-85d7-4001-b53c-d7bb40b0ab67"),
+            new(ClaimTypes.Email,"test@yahoo.com"),
+            new(ClaimTypes.GivenName,"Abc"),
+            new(ClaimTypes.Surname,"xyz"),
+            new(AuthClaimTypes.OrganisationId, "123"),
+            new(AuthClaimTypes.OrganisationName, "Test Org"),
+            new(AuthClaimTypes.OrganisationCategoryId, organisationCategoryId),
+            new(AuthClaimTypes.OrganisationEstablishmentTypeId, organisationEstablishmentType),
+            new(AuthClaimTypes.OrganisationHighAge, organisationHighAge.ToString()),
+            new(AuthClaimTypes.OrganisationLowAge, organisationLowAge.ToString()),
+            new(AuthClaimTypes.EstablishmentNumber,"89"),
+            new(AuthClaimTypes.LocalAuthorityNumber,"98"),
+            new(AuthClaimTypes.UniqueReferenceNumber,"121"),
+            new(AuthClaimTypes.UniqueIdentifier,"007"),
+            new(AuthClaimTypes.UKProviderReferenceNumber, "23432"),
+            new(ClaimTypes.Role, role)
+        }, "mock"));
 
-            return user;
-        }
+        return user;
     }
 }


### PR DESCRIPTION
## 📌 Summary

Previously instances were created, but the class is a static factory.

While I think we could make this more flexible than several named factory methods... e.g. a `ClaimsPrincipalBuilder` (and similar with HttpContext).... this PR doesn't aim to address this.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [x] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
