### PR TITLE
refactor: Remove SearchControllers inherited props `ShowMiddleNames` and `UseLAColumn`

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Common/AppSettings/AzureAppSettings.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Common/AppSettings/AzureAppSettings.cs
@@ -42,6 +42,4 @@ public class AzureAppSettings
     public int CommonTransferFileUPNLimit { get; set; }
     public int DownloadOptionsCheckLimit { get; set; }
 
-    // flag indicating that we should show the LA number
-    public bool UseLAColumn { get; set; }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/BaseLearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/BaseLearnerNumberController.cs
@@ -52,12 +52,9 @@ public abstract class BaseLearnerNumberController : Controller
     public abstract string SearchSessionKey { get; }
     public abstract string SearchSessionSortField { get; }
     public abstract string SearchSessionSortDirection { get; }
-    public abstract bool ShowLocalAuthority { get; }
-
-    public abstract bool ShowMiddleNames { get; }
     public abstract string DownloadSelectedLink { get; }
 
-    public abstract string LearnerNumberLabel { get; }
+    public string LearnerNumberLabel => Global.LearnerNumberLabel;
 
     #endregion Abstract Properties
 
@@ -93,19 +90,17 @@ public abstract class BaseLearnerNumberController : Controller
     [NonAction]
     public async Task<IActionResult> Search(bool? returnToSearch)
     {
-        var model = new LearnerNumberSearchViewModel();
+        LearnerNumberSearchViewModel model = new();
 
         PopulatePageText(model);
         PopulateNavigation(model);
-        PopulateSorting(model, this.HttpContext.Session.GetString(SearchSessionSortField), this.HttpContext.Session.GetString(SearchSessionSortDirection));
+        PopulateSorting(model, HttpContext.Session.GetString(SearchSessionSortField), HttpContext.Session.GetString(SearchSessionSortDirection));
         ClearSortingDataFromSession();
         LearnerNumberSearchViewModel.MaximumLearnerNumbersPerSearch = _appSettings.MaximumUPNsPerSearch;
 
-        model.ShowMiddleNames = this.ShowMiddleNames;
-
         SetModelApplicationLabels(model);
 
-        if (returnToSearch ?? false && this.HttpContext.Session.Keys.Contains(SearchSessionKey))
+        if (returnToSearch ?? false && HttpContext.Session.Keys.Contains(SearchSessionKey))
         {
             ModelState.Clear();
             model.LearnerNumber = this.HttpContext.Session.GetString(SearchSessionKey);
@@ -143,8 +138,6 @@ public abstract class BaseLearnerNumberController : Controller
         }
         var notPaged = hasQueryItem && !calledByController;
         var allSelected = false;
-
-        model.ShowMiddleNames = this.ShowMiddleNames;
 
         model.SearchBoxErrorMessage = ModelState.IsValid is false ? GenerateValidationMessage() : null;
 
@@ -507,8 +500,6 @@ public abstract class BaseLearnerNumberController : Controller
     {
         model.PageHeading = PageHeading;
         model.LearnerNumberLabel = LearnerNumberLabel;
-        model.ShowLocalAuthority = ShowLocalAuthority;
-
         return model;
     }
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/FELearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/FELearnerNumberController.cs
@@ -53,25 +53,17 @@ public class FELearnerNumberController : Controller
         GetAvailableDatasetsForPupilsResponse> _getAvailableDatasetsForPupilsUseCase;
 
     private readonly IEventLogger _eventLogger;
-
+    private readonly bool _showMiddleNames = false;
     public const int PAGESIZE = 20;
     public const string MISSING_LEARNER_NUMBERS_KEY = "missingLearnerNumbers";
     public const string TOTAL_SEARCH_RESULTS = "totalSearch";
 
     public string PageHeading => UniqueLearnerNumberLabels.SearchPupilUpnPageHeading;
     public string SearchAction => "PupilUlnSearch";
-    public string FullTextLearnerSearchController => Global.FELearnerTextSearchController;
-    public string FullTextLearnerSearchAction => Global.FELearnerTextSearchAction;
     public string DownloadLinksPartial => "~/Views/Shared/LearnerNumber/_SearchFurtherEducationDownloadLinks.cshtml";
-    public AzureSearchIndexType IndexType => AzureSearchIndexType.FurtherEducation;
     public string SearchSessionKey => "SearchULN_SearchText";
     public string SearchSessionSortField => "SearchULN_SearchTextSortField";
     public string SearchSessionSortDirection => "SearchULN_SearchTextSortDirection";
-    public bool ShowLocalAuthority => false;
-    public bool ShowMiddleNames => false;
-    public string DownloadSelectedLink => ApplicationLabels.DownloadSelectedFurtherEducationLink;
-    public string LearnerNumberLabel => Global.FELearnerNumberLabel;
-    public string InvalidUPNsConfirmationAction => "";
 
     public FELearnerNumberController(
         IUseCase<
@@ -309,7 +301,7 @@ public class FELearnerNumberController : Controller
         ClearSortingDataFromSession();
         LearnerNumberSearchViewModel.MaximumLearnerNumbersPerSearch = _appSettings.MaximumUPNsPerSearch;
 
-        model.ShowMiddleNames = ShowMiddleNames;
+        model.ShowMiddleNames = _showMiddleNames;
 
         SetModelApplicationLabels(model);
 
@@ -359,7 +351,7 @@ public class FELearnerNumberController : Controller
         bool notPaged = hasQueryItem && !calledByController;
         bool allSelected = false;
 
-        model.ShowMiddleNames = ShowMiddleNames;
+        model.ShowMiddleNames = _showMiddleNames;
 
         model.SearchBoxErrorMessage = ModelState.IsValid is false ? GenerateValidationMessage() : null;
 
@@ -414,7 +406,7 @@ public class FELearnerNumberController : Controller
     private void SetModelApplicationLabels(LearnerNumberSearchViewModel model)
     {
         model.AddSelectedToMyPupilListLink = ApplicationLabels.AddSelectedToMyPupilListLink;
-        model.DownloadSelectedLink = DownloadSelectedLink;
+        model.DownloadSelectedLink = ApplicationLabels.DownloadSelectedFurtherEducationLink;
         model.DownloadSelectedASCTFLink = ApplicationLabels.DownloadSelectedAsCtfLink;
     }
 
@@ -637,8 +629,8 @@ public class FELearnerNumberController : Controller
     protected LearnerNumberSearchViewModel PopulatePageText(LearnerNumberSearchViewModel model)
     {
         model.PageHeading = PageHeading;
-        model.LearnerNumberLabel = LearnerNumberLabel;
-        model.ShowLocalAuthority = ShowLocalAuthority;
+        model.LearnerNumberLabel = Global.FELearnerNumberLabel;
+        model.ShowLocalAuthority = false;
 
         return model;
     }
@@ -646,10 +638,10 @@ public class FELearnerNumberController : Controller
     protected LearnerNumberSearchViewModel PopulateNavigation(LearnerNumberSearchViewModel model)
     {
         model.DownloadLinksPartial = DownloadLinksPartial;
-        model.InvalidUPNsConfirmationAction = InvalidUPNsConfirmationAction;
+        model.InvalidUPNsConfirmationAction = string.Empty;
         model.SearchAction = SearchAction;
-        model.FullTextLearnerSearchController = FullTextLearnerSearchController;
-        model.FullTextLearnerSearchAction = FullTextLearnerSearchAction;
+        model.FullTextLearnerSearchController = Global.FELearnerTextSearchController;
+        model.FullTextLearnerSearchAction = Global.FELearnerTextSearchAction;
         return model;
     }
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/NPDLearnerNumberSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/NPDLearnerNumberSearchController.cs
@@ -41,11 +41,7 @@ public class NPDLearnerNumberSearchController : BaseLearnerNumberController
     public override string SearchSessionKey => "SearchNPD_SearchText";
     public override string SearchSessionSortField => "SearchNPD_SearchTextSortField";
     public override string SearchSessionSortDirection => "SearchNPD_SearchTextSortDirection";
-    public override bool ShowLocalAuthority => _appSettings.UseLAColumn;
-    public override bool ShowMiddleNames => true;
     public override string DownloadSelectedLink => ApplicationLabels.DownloadSelectedNationalPupilDatabaseDataLink;
-
-    public override string LearnerNumberLabel => Global.LearnerNumberLabel;
 
     private readonly IUseCase<GetAvailableDatasetsForPupilsRequest, GetAvailableDatasetsForPupilsResponse> _getAvailableDatasetsForPupilsUseCase;
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/PupilPremiumLearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/LearnerNumber/PupilPremiumLearnerNumberController.cs
@@ -36,10 +36,7 @@ public class PupilPremiumLearnerNumberController : BaseLearnerNumberController
     public override string SearchSessionKey => "SearchPPUPN_SearchText";
     public override string SearchSessionSortField => "SearchPPUPN_SearchTextSortField";
     public override string SearchSessionSortDirection => "SearchPPUPN_SearchTextSortDirection";
-    public override bool ShowLocalAuthority => _appSettings.UseLAColumn;
-    public override bool ShowMiddleNames => true;
     public override string DownloadSelectedLink => ApplicationLabels.DownloadSelectedPupilPremiumDataLink;
-    public override string LearnerNumberLabel => Global.LearnerNumberLabel;
 
 
     public PupilPremiumLearnerNumberController(ILogger<PupilPremiumLearnerNumberController> logger,

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/BaseLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/BaseLearnerTextSearchController.cs
@@ -30,7 +30,6 @@ public abstract class BaseLearnerTextSearchController : Controller
 {
     public const int PAGESIZE = 20;
     private const string PersistedSelectedSexFiltersKey = "PersistedSelectedSexFilters";
-
     private readonly ILogger<BaseLearnerTextSearchController> _logger;
     private readonly IPaginatedSearchService _paginatedSearch;
     private readonly ITextSearchSelectionManager _selectionManager;
@@ -65,10 +64,8 @@ public abstract class BaseLearnerTextSearchController : Controller
     public abstract string LearnerTextSearchController { get; }
     public abstract string LearnerTextSearchAction { get; }
     public abstract string LearnerNumberAction { get; }
-    public abstract bool ShowLocalAuthority { get; }
     public abstract string InvalidUPNsConfirmationAction { get; }
     public abstract string LearnerNumberLabel { get; }
-    public abstract bool ShowMiddleNames { get; }
     public abstract string DownloadSelectedLink { get; }
 
 
@@ -108,8 +105,6 @@ public abstract class BaseLearnerTextSearchController : Controller
         PopulatePageText(model);
         PopulateNavigation(model);
         model.LearnerNumberLabel = LearnerNumberLabel;
-
-        model.ShowMiddleNames = ShowMiddleNames;
 
         if (returnToSearch ?? false)
         {
@@ -200,8 +195,6 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         PopulatePageText(model);
         PopulateNavigation(model);
-
-        model.ShowMiddleNames = ShowMiddleNames;
 
         _sessionProvider.SetSessionValue(SearchSessionKey, model.SearchText);
 
@@ -546,7 +539,6 @@ public abstract class BaseLearnerTextSearchController : Controller
         List<CurrentFilterDetail> currentFilters = SetCurrentFilters(model, surnameFilter, middlenameFilter, foremameFilter, searchByRemove);
 
         model.LearnerTextDatabaseName = LearnerTextDatabaseName;
-        model.ShowMiddleNames = this.ShowMiddleNames;
 
         model = SetSearchFiltersUrls(model);
 
@@ -1037,7 +1029,6 @@ public abstract class BaseLearnerTextSearchController : Controller
     protected LearnerTextSearchViewModel PopulatePageText(LearnerTextSearchViewModel model)
     {
         model.PageHeading = PageHeading;
-        model.ShowLocalAuthority = ShowLocalAuthority;
         return model;
     }
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/FELearnerTextSearchController.cs
@@ -2,8 +2,6 @@
 using DfE.GIAP.Common.AppSettings;
 using DfE.GIAP.Common.Constants;
 using DfE.GIAP.Common.Enums;
-using DfE.GIAP.Core.Common.Application;
-using DfE.GIAP.Core.MyPupils.Application.UseCases.AddPupilsToMyPupils;
 using DfE.GIAP.Common.Helpers;
 using DfE.GIAP.Core.Common.Application;
 using DfE.GIAP.Core.Common.CrossCutting;
@@ -67,7 +65,6 @@ public class FELearnerTextSearchController : Controller
     public string SearchController => Global.FELearnerTextSearchController;
     public ReturnRoute ReturnRoute => ReturnRoute.NonUniqueLearnerNumber;
 
-    public bool ShowLocalAuthority => false;
     public string InvalidUPNsConfirmationAction => "";
     public string LearnerNumberLabel => Global.FELearnerNumberLabel;
     public bool ShowMiddleNames => false;
@@ -948,7 +945,7 @@ public class FELearnerTextSearchController : Controller
     protected LearnerTextSearchViewModel PopulatePageText(LearnerTextSearchViewModel model)
     {
         model.PageHeading = PageHeading; 
-        model.ShowLocalAuthority = ShowLocalAuthority;
+        model.ShowLocalAuthority = false;
         return model;
     }
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/NPDLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/NPDLearnerTextSearchController.cs
@@ -65,10 +65,8 @@ public class NPDLearnerTextSearchController : BaseLearnerTextSearchController
     public override string LearnerTextSearchController => Global.NPDTextSearchController;
     public override string LearnerTextSearchAction => SearchAction;
     public override string LearnerNumberAction => Global.NPDAction;
-    public override bool ShowLocalAuthority => _appSettings.UseLAColumn;
     public override string InvalidUPNsConfirmationAction => Global.NPDNonUpnInvalidUPNsConfirmation;
     public override string LearnerNumberLabel => Global.LearnerNumberLabel;
-    public override bool ShowMiddleNames => true;
     public override string DownloadSelectedLink => ApplicationLabels.DownloadSelectedNationalPupilDatabaseDataLink;
 
     private readonly IUseCase<GetAvailableDatasetsForPupilsRequest, GetAvailableDatasetsForPupilsResponse> _getAvailableDatasetsForPupilsUseCase;

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/PPLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/PPLearnerTextSearchController.cs
@@ -60,10 +60,8 @@ public class PPLearnerTextSearchController : BaseLearnerTextSearchController
     public override string LearnerTextSearchAction => SearchAction;
     public override string LearnerNumberAction => Global.PPAction;
     
-    public override bool ShowLocalAuthority => _appSettings.UseLAColumn;
     public override string InvalidUPNsConfirmationAction => Global.PPNonUpnInvalidUPNsConfirmation;
     public override string LearnerNumberLabel => Global.LearnerNumberLabel;
-    public override bool ShowMiddleNames => true;
 
     public override string DownloadSelectedLink => ApplicationLabels.DownloadSelectedPupilPremiumDataLink;
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/Search/LearnerNumberSearchViewModel.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/Search/LearnerNumberSearchViewModel.cs
@@ -8,7 +8,6 @@ namespace DfE.GIAP.Web.ViewModels.Search;
 [ExcludeFromCodeCoverage]
 public class LearnerNumberSearchViewModel
 {
-    public string PageTitle { get; set; }
     public string PageHeading { get; set; }
 
     public string SearchAction { get; set; }
@@ -16,10 +15,9 @@ public class LearnerNumberSearchViewModel
     public string FullTextLearnerSearchController { get; set; }
     public string FullTextLearnerSearchAction { get; set; }
 
-
-    public bool ShowMiddleNames { get; set; }
+    public bool ShowMiddleNames { get; set; } = true;
+    public bool ShowLocalAuthority { get; set; } = true;
     public string DownloadLinksPartial { get; set; }
-    public bool ShowLocalAuthority { get; set; }
 
     public string LearnerNumberLabel { get; set; }
     public static int MaximumLearnerNumbersPerSearch { get; set; }
@@ -39,7 +37,6 @@ public class LearnerNumberSearchViewModel
     public bool ToggleSelectAll { get; set; } = true;
     public bool ShowErrors { get; set; }
     public bool NoPupil { get; set; }
-    public string SelectedInvalidUPNOption { get; set; }
     public int PageNumber { get; set; }
     public int PageSize { get; set; }
     public string SortField { get; set; }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/Search/LearnerTextSearchViewModel.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/ViewModels/Search/LearnerTextSearchViewModel.cs
@@ -38,7 +38,7 @@ public class LearnerTextSearchViewModel
     public int Offset => PageNumber * PageSize;
     public bool ShowLocalAuthority { get; set; }
 
-    public bool ShowMiddleNames { get; set; }
+    public bool ShowMiddleNames { get; set; } = true;
     public string LearnerNumberLabel { get; set; }
 
     [Required(ErrorMessage = "Enter a first name and/or surname")]

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/FELearnerNumberControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Controllers/Search/LearnerNumber/FELearnerNumberControllerTests.cs
@@ -1870,9 +1870,9 @@ public class FELearnerNumberControllerTests : IClassFixture<PaginatedResultsFake
         Assert.Equal(controller.PageHeading, model.PageHeading);
         Assert.Equal(controller.DownloadLinksPartial, model.DownloadLinksPartial);
         Assert.Equal(controller.SearchAction, model.SearchAction);
-        Assert.Equal(controller.FullTextLearnerSearchController, model.FullTextLearnerSearchController);
-        Assert.Equal(controller.FullTextLearnerSearchAction, model.FullTextLearnerSearchAction);
-        Assert.Equal(controller.ShowLocalAuthority, model.ShowLocalAuthority);
+        Assert.Equal(Global.FELearnerTextSearchController, model.FullTextLearnerSearchController);
+        Assert.Equal(Global.FELearnerTextSearchAction, model.FullTextLearnerSearchAction);
+        Assert.False(model.ShowLocalAuthority);
     }
 
     private FELearnerNumberController GetController()


### PR DESCRIPTION
## 📌 Summary

It appears PP and NPD should both display middleNames and the LA column. FE should not display either.

This removes some inheritance and just sets the model props directly.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [x] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
