### PR TITLE
refactor: Remove identical properties in PP/NPD controllers into BaseLearnerNumberController

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/BaseLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/BaseLearnerTextSearchController.cs
@@ -44,15 +44,14 @@ public abstract class BaseLearnerTextSearchController : Controller
     public abstract string SortFieldKey { get; }
     public abstract string SearchAction { get; }
     public abstract string SearchController { get; }
-    public abstract string SearchLearnerNumberController { get; }
+    public string SearchLearnerNumberController => Routes.Application.Search;
     public abstract string SearchLearnerNumberAction { get; }
     public abstract string RedirectUrlFormAction { get; }
-    public abstract string LearnerTextDatabaseAction { get; }
     public abstract string RedirectFrom { get; }
     public abstract string LearnerTextDatabaseName { get; }
     public abstract string FormAction { get; }
     public abstract string RemoveActionUrl { get; }
-    public abstract string SearchView { get; }
+    public string SearchView => Global.NonUpnSearchView;
     public abstract string DobFilterUrl { get; }
     public abstract string ForenameFilterUrl { get; }
     public abstract string MiddlenameFilterUrl { get; }
@@ -61,11 +60,8 @@ public abstract class BaseLearnerTextSearchController : Controller
     public abstract string DownloadLinksPartial { get; }
     public abstract AzureSearchIndexType IndexType { get; }
     public abstract ReturnRoute ReturnRoute { get; }
-    public abstract string LearnerTextSearchController { get; }
-    public abstract string LearnerTextSearchAction { get; }
-    public abstract string LearnerNumberAction { get; }
     public abstract string InvalidUPNsConfirmationAction { get; }
-    public abstract string LearnerNumberLabel { get; }
+    public string LearnerNumberLabel => Global.LearnerNumberLabel;
     public abstract string DownloadSelectedLink { get; }
 
 
@@ -149,7 +145,7 @@ public abstract class BaseLearnerTextSearchController : Controller
         GetPersistedSexFiltersForViewModel(model);
         model.SearchText = SecurityHelper.SanitizeText(model.SearchText);
         model.LearnerNumberLabel = LearnerNumberLabel;
-        var notPaged = hasQueryItem || calledByController;
+        bool notPaged = hasQueryItem || calledByController;
 
         if (notPaged && !model.NoPupilSelected)
         {
@@ -225,9 +221,9 @@ public abstract class BaseLearnerTextSearchController : Controller
     [NonAction]
     public async Task<IActionResult> DobSearchFilter(LearnerTextSearchViewModel model)
     {
-        var day = model.SearchFilters.CustomFilterText.DobDay;
-        var month = model.SearchFilters.CustomFilterText.DobMonth;
-        var year = model.SearchFilters.CustomFilterText.DobYear;
+        int day = model.SearchFilters.CustomFilterText.DobDay;
+        int month = model.SearchFilters.CustomFilterText.DobMonth;
+        int year = model.SearchFilters.CustomFilterText.DobYear;
 
         ModelState.Clear();
 
@@ -277,7 +273,7 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         if (!model.FilterErrors.DobError && (year < 0 || year > 0))
         {
-            var yearLimit = DateTime.Now.Year - 3;
+            int yearLimit = DateTime.Now.Year - 3;
             if (year > yearLimit)
             {
                 ModelState.AddModelError("YearLimitHigh", Messages.Search.Errors.DobInvalid);
@@ -379,7 +375,7 @@ public abstract class BaseLearnerTextSearchController : Controller
     protected void GetPersistedSexFiltersForViewModel(
         LearnerTextSearchViewModel model)
     {
-        var sexFilters =
+        string[] sexFilters =
             TempData.GetPersistedObject<string[]>(
                 PersistedSelectedSexFiltersKey,
                 keepTempDataBetweenRequests: true);
@@ -512,7 +508,7 @@ public abstract class BaseLearnerTextSearchController : Controller
     [NonAction]
     public IActionResult ConfirmationForStarredPupil(StarredPupilConfirmationViewModel model)
     {
-        var searchViewModel = new LearnerTextSearchViewModel()
+        LearnerTextSearchViewModel searchViewModel = new LearnerTextSearchViewModel()
         {
             SearchText = this.HttpContext.Session.Keys.Contains(SearchSessionKey) ? this.HttpContext.Session.GetString(SearchSessionKey) : string.Empty,
             LearnerTextSearchController = SearchController,
@@ -560,14 +556,14 @@ public abstract class BaseLearnerTextSearchController : Controller
             }
         }
 
-        var hasCustomFilters = (model.SearchFilters.CustomFilterText.Surname != null ||
+        bool hasCustomFilters = (model.SearchFilters.CustomFilterText.Surname != null ||
             model.SearchFilters.CustomFilterText.Forename != null ||
             model.SearchFilters.CustomFilterText.Middlename != null ||
             model.SearchFilters.CustomFilterText.DobDay != 0 ||
             model.SearchFilters.CustomFilterText.DobMonth != 0 ||
             model.SearchFilters.CustomFilterText.DobYear != 0) ? true : false;
 
-        var first = hasCustomFilters || model.PageNumber != 0 ? false : true;
+        bool first = hasCustomFilters || model.PageNumber != 0 ? false : true;
         model = await GetPupilsByNameForSearchBuilder(
             model,
             IndexType,
@@ -589,7 +585,7 @@ public abstract class BaseLearnerTextSearchController : Controller
         string sortField = "",
         string sortDirection = "")
     {
-        var requestFilters = GenerateRequestModel(model, currentFilters);
+        Dictionary<string, string[]> requestFilters = GenerateRequestModel(model, currentFilters);
         PaginatedResponse result = await _paginatedSearch.GetPage(
             model.SearchText,
             requestFilters,
@@ -604,8 +600,8 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         ParseSex(ref result);
 
-        var lowAge = User.GetOrganisationLowAge();
-        var highAge = User.GetOrganisationHighAge();
+        int lowAge = User.GetOrganisationLowAge();
+        int highAge = User.GetOrganisationHighAge();
 
         model.Learners = result.Learners;
         model.Count = (int)result.Count;
@@ -615,17 +611,17 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         SetLearnerNumberId(model);
 
-        var isAdmin = User.IsAdmin();
+        bool isAdmin = User.IsAdmin();
         if (!isAdmin && indexType != AzureSearchIndexType.FurtherEducation)
         {
             model.Learners = RbacHelper.CheckRbacRulesGeneric<Learner>(model.Learners.ToList(), lowAge, highAge);
         }
 
-        var selected = GetSelected();
+        string selected = GetSelected();
 
         if (!string.IsNullOrEmpty(selected))
         {
-            foreach (var learner in model.Learners)
+            foreach (Learner learner in model.Learners)
             {
                 if (!string.IsNullOrEmpty(learner.LearnerNumberId))
                 {
@@ -645,9 +641,9 @@ public abstract class BaseLearnerTextSearchController : Controller
 
     private async Task<InvalidLearnerNumberSearchViewModel> GetInvalidPupil(InvalidLearnerNumberSearchViewModel model, AzureSearchIndexType indexType)
     {
-        var searchInput = model.LearnerNumber.ToDecryptedSearchText();
+        string searchInput = model.LearnerNumber.ToDecryptedSearchText();
 
-        var result = await _paginatedSearch.GetPage(
+        PaginatedResponse result = await _paginatedSearch.GetPage(
           searchInput,
             null,
             1,
@@ -659,7 +655,7 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         model.Learners = result.Learners ?? new List<Learner>();
 
-        var nonUPNResult = await _paginatedSearch.GetPage(
+        PaginatedResponse nonUPNResult = await _paginatedSearch.GetPage(
         searchInput,
         null,
         1,
@@ -671,10 +667,10 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         model.Learners = model.Learners.Union(nonUPNResult.Learners);
         model.Learners.ToList().ForEach(x => x.LearnerNumberId = x.LearnerNumber);
-        var lowAge = User.GetOrganisationLowAge();
-        var highAge = User.GetOrganisationHighAge();
+        int lowAge = User.GetOrganisationLowAge();
+        int highAge = User.GetOrganisationHighAge();
 
-        var isAdmin = User.IsAdmin();
+        bool isAdmin = User.IsAdmin();
         if (!isAdmin && indexType != AzureSearchIndexType.FurtherEducation)
         {
             model.Learners = RbacHelper.CheckRbacRulesGeneric<Learner>(model.Learners.ToList(), lowAge, highAge);
@@ -685,7 +681,7 @@ public abstract class BaseLearnerTextSearchController : Controller
 
     private Dictionary<string, string[]> GenerateRequestModel(LearnerTextSearchViewModel model, List<CurrentFilterDetail> currentFilters)
     {
-        var requestFilters = new Dictionary<string, string[]>();
+        Dictionary<string, string[]> requestFilters = new Dictionary<string, string[]>();
         List<string> surnameList = new List<string>();
         List<string> middlenameList = new List<string>();
         List<string> forenameList = new List<string>();
@@ -693,7 +689,7 @@ public abstract class BaseLearnerTextSearchController : Controller
 
         if (currentFilters != null)
         {
-            foreach (var filter in currentFilters)
+            foreach (CurrentFilterDetail filter in currentFilters)
             {
                 if (filter.FilterType == FilterType.Surname)
                 {

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/NPDLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/NPDLearnerTextSearchController.cs
@@ -41,7 +41,6 @@ public class NPDLearnerTextSearchController : BaseLearnerTextSearchController
 
     public override string SearchLearnerNumberAction => Routes.NationalPupilDatabase.NationalPupilDatabaseLearnerNumber;
     public override string RedirectUrlFormAction => Global.NPDNonUpnAction;
-    public override string LearnerTextDatabaseAction => Global.NPDNonUpnAction;
     public override string LearnerTextDatabaseName => Global.NPDLearnerTextSearchDatabaseName;
     public override string RedirectFrom => Routes.NationalPupilDatabase.NationalPupilDatabaseNonUPN;
 
@@ -54,19 +53,11 @@ public class NPDLearnerTextSearchController : BaseLearnerTextSearchController
     public override string FormAction => Routes.NationalPupilDatabase.NationalPupilDatabaseNonUPN;
     public override string RemoveActionUrl => $"/{Routes.Application.Search}/{Routes.NationalPupilDatabase.NationalPupilDatabaseNonUPN}";
     public override AzureSearchIndexType IndexType => AzureSearchIndexType.NPD;
-    public override string SearchView => Global.NonUpnSearchView;
-
-
-    public override string SearchLearnerNumberController => Routes.Application.Search;
 
     public override string SearchAction => Global.NPDNonUpnAction;
     public override string SearchController => Global.NPDTextSearchController;
     public override ReturnRoute ReturnRoute => Common.Enums.ReturnRoute.NonNationalPupilDatabase;
-    public override string LearnerTextSearchController => Global.NPDTextSearchController;
-    public override string LearnerTextSearchAction => SearchAction;
-    public override string LearnerNumberAction => Global.NPDAction;
     public override string InvalidUPNsConfirmationAction => Global.NPDNonUpnInvalidUPNsConfirmation;
-    public override string LearnerNumberLabel => Global.LearnerNumberLabel;
     public override string DownloadSelectedLink => ApplicationLabels.DownloadSelectedNationalPupilDatabaseDataLink;
 
     private readonly IUseCase<GetAvailableDatasetsForPupilsRequest, GetAvailableDatasetsForPupilsResponse> _getAvailableDatasetsForPupilsUseCase;

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/PPLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Controllers/TextBasedSearch/PPLearnerTextSearchController.cs
@@ -37,7 +37,6 @@ public class PPLearnerTextSearchController : BaseLearnerTextSearchController
     public override string DownloadLinksPartial => Global.PPNonUpnDownloadLinksView;
     public override string SearchLearnerNumberAction => Routes.PupilPremium.PupilPremiumDatabase;
     public override string RedirectUrlFormAction => Global.PPNonUpnAction;
-    public override string LearnerTextDatabaseAction => Global.PPNonUpnAction;
     public override string LearnerTextDatabaseName => Global.PPLearnerTextSearchDatabaseName;
     public override string RedirectFrom => Routes.PupilPremium.NonUPN;
 
@@ -50,18 +49,11 @@ public class PPLearnerTextSearchController : BaseLearnerTextSearchController
     public override string FormAction => Routes.PupilPremium.NonUPN;
     public override string RemoveActionUrl => $"/{Routes.Application.Search}/{Routes.PupilPremium.NonUPN}";
     public override AzureSearchIndexType IndexType => AzureSearchIndexType.PupilPremium;
-    public override string SearchView => Global.NonUpnSearchView;
-
-    public override string SearchLearnerNumberController => Routes.Application.Search;
     public override string SearchAction => Global.PPNonUpnAction;
     public override string SearchController => Global.PPNonUpnController;
     public override ReturnRoute ReturnRoute => Common.Enums.ReturnRoute.NonPupilPremium;
-    public override string LearnerTextSearchController => Global.PPNonUpnController;
-    public override string LearnerTextSearchAction => SearchAction;
-    public override string LearnerNumberAction => Global.PPAction;
     
     public override string InvalidUPNsConfirmationAction => Global.PPNonUpnInvalidUPNsConfirmation;
-    public override string LearnerNumberLabel => Global.LearnerNumberLabel;
 
     public override string DownloadSelectedLink => ApplicationLabels.DownloadSelectedPupilPremiumDataLink;
 


### PR DESCRIPTION
## 📌 Summary

Continuing to rationalise the unnecessary inheritance in the Search controllers. 

Some are identical, so remove these as overriden properties.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [x] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
