### PR TITLE
fix: add antifgorg to PupilPremiumNumber > PupilPremium action

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Search/PupilPremium/SearchByUniquePupilNumber/PupilPremiumLearnerNumberController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Search/PupilPremium/SearchByUniquePupilNumber/PupilPremiumLearnerNumberController.cs
@@ -110,6 +110,7 @@ public class PupilPremiumLearnerNumberController : Controller
 
     [Route(Routes.Application.PupilPremium)]
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> PupilPremium(
         [FromForm] LearnerNumberSearchViewModel model,
         [FromQuery] int pageNumber,


### PR DESCRIPTION
## 📌 Summary

The PupilPremium action is a `POST`, which should be exercised when SearchResults are presented. 

So this adds the `ValidateAntiForgery` attribute to this action.

This was highlighted in #540 and #534 

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
