### PR TITLE
fix: MyPupils extend request model to take full FormState

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/DownloadMyPupils/DownloadMyPupilsController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/DownloadMyPupils/DownloadMyPupilsController.cs
@@ -72,10 +72,10 @@ public class DownloadMyPupilsController : Controller
     [Route(Routes.DownloadCommonTransferFile.DownloadCommonTransferFileAction)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ToDownloadCommonTransferFileData(
-        [FromForm] List<string> SelectedPupils,
+        MyPupilsFormStateRequestDto updateForm,
         MyPupilsQueryRequestDto query)
     {
-        List<string> updatedPupils = await UpsertSelectedPupilsAsync(SelectedPupils);
+        List<string> updatedPupils = await UpsertSelectedPupilsAsync(updateForm);
 
         if (updatedPupils.Count == 0)
         {
@@ -126,9 +126,11 @@ public class DownloadMyPupilsController : Controller
     [Route(Routes.PupilPremium.LearnerNumberDownloadRequest)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ToDownloadSelectedPupilPremiumDataUPN(
-        [FromForm] List<string> SelectedPupils, MyPupilsQueryRequestDto query, CancellationToken ctx = default)
+        MyPupilsFormStateRequestDto updateForm,
+        MyPupilsQueryRequestDto query,
+        CancellationToken ctx = default)
     {
-        List<string> updatedPupils = await UpsertSelectedPupilsAsync(SelectedPupils);
+        List<string> updatedPupils = await UpsertSelectedPupilsAsync(updateForm);
 
         if (updatedPupils.Count == 0)
         {
@@ -169,9 +171,9 @@ public class DownloadMyPupilsController : Controller
     [HttpPost]
     [Route(Routes.MyPupilList.DownloadOptionsRoute)]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> GetDownloadNpdOptions([FromForm] List<string> SelectedPupils, MyPupilsQueryRequestDto query)
+    public async Task<IActionResult> GetDownloadNpdOptions(MyPupilsFormStateRequestDto updateForm, MyPupilsQueryRequestDto query)
     {
-        List<string> updatedPupils = await UpsertSelectedPupilsAsync(SelectedPupils);
+        List<string> updatedPupils = await UpsertSelectedPupilsAsync(updateForm);
 
         if (updatedPupils.Count == 0)
         {
@@ -282,14 +284,12 @@ public class DownloadMyPupilsController : Controller
     }
 
 
-    private async Task<List<string>> UpsertSelectedPupilsAsync(List<string> selectedPupils)
+    private async Task<List<string>> UpsertSelectedPupilsAsync(MyPupilsFormStateRequestDto? updateForm)
     {
-        MyPupilsFormStateRequestDto request = new()
+        if(updateForm != null)
         {
-            SelectedPupils = selectedPupils
-        };
-
-        await _updateMyPupilsPupilSelectionsCommandHandler.Handle(request);
+            await _updateMyPupilsPupilSelectionsCommandHandler.Handle(updateForm);
+        }
 
         List<string> allSelectedPupils =
             (await _getSelectedPupilsPresentationHandler.GetSelectedPupilsAsync(userId: User.GetUserId()))


### PR DESCRIPTION
## 📌 Summary

Bug: Pupil deselections do not get taken into account, when DownloadNPD/CTF/PP is selected, so if anything on current page is deselected, this is not reflected on the subsequent page.

This passes the full FormUpdate dto that changes form state, and delegates to update.

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
