### PR TITLE
fix: NPD search index do not pass Forename or Surname yet

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
@@ -112,8 +112,6 @@
                     "SurnameLC"
                 ],
                 "SearchFields": [
-                    "Forename",
-                    "Surname",
                     "UPN"
                 ]
             },


### PR DESCRIPTION
## 📌 Summary

Forename and Surname are not searchable yet on the indexes, so until that happens, cannot apply this, otherwise search request fails.

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
