### PR TITLE
Revert "refactor: Remove SortFieldOptions and PartialTextSanitisation…

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/DfE.GIAP.Core.csproj
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/DfE.GIAP.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="DfE.CleanArchitecture.Common.CrossCutting" Version="0.0.1-5" />
     <PackageReference Include="DfE.CleanArchitecture.Common.Domain" Version="0.0.1-5" />
     <PackageReference Include="Dfe.Data.Common.Infrastructure.Persistence.CosmosDb" Version="2.0.0-0" />
-    <PackageReference Include="Dfe.Data.Common.Infrastructure.CognitiveSearch" Version="1.0.2-89" />
+    <PackageReference Include="Dfe.Data.Common.Infrastructure.CognitiveSearch" Version="1.0.2-87" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Search/Shared/SearchRules/PartialWordMatchAndTextSanitisationRule.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Search/Shared/SearchRules/PartialWordMatchAndTextSanitisationRule.cs
@@ -1,0 +1,40 @@
+﻿using System.Text;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Options;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.SearchRules;
+
+namespace DfE.GIAP.Web.Features.Search.Shared.SearchRules;
+
+/// <summary>
+/// Facilitates search rules to be specified when running a search
+/// </summary>
+public class PartialWordMatchAndTextSanitisationRule : ISearchRule
+{
+    private readonly SearchRuleOptions _ruleOptions;
+    private readonly PartialWordMatchRule _partialWordMatchRule;
+
+    /// <summary>
+    /// Construct the saerch rules provider, injecting into it the <see cref="SearchRuleOptions"/> to be applied
+    /// </summary>
+    /// <param name="searchRuleOptions"></param>
+    public PartialWordMatchAndTextSanitisationRule(
+        SearchRuleOptions searchRuleOptions,
+        PartialWordMatchRule partialWordMatchRule)
+    {
+        _ruleOptions = searchRuleOptions;
+        _partialWordMatchRule = partialWordMatchRule;
+    }
+
+    /// <summary>
+    /// Apply search rules as specified in the options
+    /// </summary>
+    /// <param name="searchKeyword"></param>
+    /// <returns></returns>
+    public string ApplySearchRules(string searchKeyword) =>
+        _ruleOptions.SearchRule == "PartialWordMatchAndTextSanitisation" ?
+            _partialWordMatchRule.ApplySearchRules(
+                new StringBuilder(searchKeyword.TrimEnd())
+                .Replace("-", " ")
+                .ToString()) :
+            searchKeyword;
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
@@ -159,6 +159,9 @@
             ]
         }
     },
+    "SearchRuleOptions": {
+        "SearchRule": "PartialWordMatchAndTextSanitisation"
+    },
     "FilterKeyToFilterExpressionMapOptions": {
         "FilterChainingLogicalOperator": "AndLogicalOperator",
         "SearchFilterToExpressionMap": {

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Search/Shared/SearchRules/PartialWordMatchAndTextSanitisationRuleTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/Search/Shared/SearchRules/PartialWordMatchAndTextSanitisationRuleTests.cs
@@ -1,0 +1,47 @@
+﻿using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.Options;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch.SearchByKeyword.SearchRules;
+using DfE.GIAP.Web.Features.Search.Shared.SearchRules;
+using Xunit;
+
+namespace DfE.GIAP.Web.Tests.Features.Search.Shared.SearchRules;
+
+public class PartialWordMatchAndTextSanitisationRuleTests
+{
+    [Fact]
+    public void ApplySearchRules_WithMatchingRule_ReplacesHyphensAndAppliesPartialMatch()
+    {
+        // Arrange
+        const string input = "hello-world-search";
+        const string expectedSanitised = "hello world search";
+
+        SearchRuleOptions options = new() { SearchRule = "PartialWordMatchAndTextSanitisation" };
+
+        PartialWordMatchRule partialMatchRule = new(options);
+
+        PartialWordMatchAndTextSanitisationRule rule = new(options, partialMatchRule);
+
+        // Act
+        string result = rule.ApplySearchRules(input);
+
+        // Assert
+        Assert.Equal(expectedSanitised, result);
+    }
+
+    [Fact]
+    public void ApplySearchRules_WithNonMatchingRule_ReturnsOriginalInput()
+    {
+        // Arrange
+        const string input = "hello-world-search";
+        SearchRuleOptions options = new() { SearchRule = "SomeOtherRule" };
+
+        PartialWordMatchRule partialMatchRule = new(options);
+
+        PartialWordMatchAndTextSanitisationRule rule = new(options, partialMatchRule);
+
+        // Act
+        string result = rule.ApplySearchRules(input);
+
+        // Assert
+        Assert.Equal(input, result);
+    }
+}


### PR DESCRIPTION
…Rule (#562)"

This reverts commit 83e7993a3f955cc934f7ad65ac5dac72a5dd9116.

PupilPremium text search breaks for some reason, as a result of this change @aahmed-dfe to figure out why

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## ✅ Checklist
- [x] Code compiles
- [x] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
