### PR TITLE
fix: Update config to 10_000 limit on index results

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
@@ -73,19 +73,19 @@
             "further-education": {
                 "SearchIndex": "idx-further-education-v3-a",
                 "SearchMode": 0,
-                "Size": 100000,
+                "Size": 10000,
                 "IncludeTotalCount": true
             },
             "npd": {
                 "SearchIndex": "idx-pupil-noskill-v2-a",
                 "SearchMode": 0,
-                "Size": 100000,
+                "Size": 10000,
                 "IncludeTotalCount": true
             },
             "pupil-premium": {
                 "SearchIndex": "idx-pupil-premium-v3-a",
                 "SearchMode": 0,
-                "Size": 100000,
+                "Size": 10000,
                 "IncludeTotalCount": true
             }
         }


### PR DESCRIPTION
## 📌 Summary

Issue to come to optimise UPN vs text matching 
Slow speed when retrieving over this amount for open matches on common names e.g. James

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
