### PR TITLE
chore: Remove appsettings SortFields for FE - Gender and Middlename not a valid sortfield

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/appsettings.json
@@ -148,9 +148,7 @@
         "SortFields": {
             "further-education": [
                 "Forename",
-                "Middlenames",
                 "Surname",
-                "Gender",
                 "Sex",
                 "DOB",
                 "search.score()"


### PR DESCRIPTION
## 📌 Summary

As per title, neither are valid sort fields for FE search

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [x] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
