### PR TITLE
fix: NpdDownloadOptions ReturnToSearch shows no results

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Search/NationalPupilDatabase/SearchByName/NationalPupilDatabaseLearnerTextSearchController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/Search/NationalPupilDatabase/SearchByName/NationalPupilDatabaseLearnerTextSearchController.cs
@@ -631,6 +631,7 @@ public sealed class NationalPupilDatabaseLearnerTextSearchController : Controlle
         PopulatePageText(model);
         PopulateNavigation(model);
         model.LearnerNumberLabel = LearnerNumberLabel;
+        model.PageSize = PAGESIZE;
 
         if (returnToSearch ?? false)
         {
@@ -649,7 +650,6 @@ public sealed class NationalPupilDatabaseLearnerTextSearchController : Controlle
                 model.SortField,
                 model.SortDirection);
             model.PageNumber = 0;
-            model.PageSize = PAGESIZE;
         }
 
         if (!returnToSearch.HasValue)


### PR DESCRIPTION
## 📌 Summary

Mapper would .Take() on Model.PageSize, which needed to be set before the map occured. It would have the results, just drop them as the Take occured.

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
