### PR TITLE
fix: Routing to DeleteMyPupils Index action `Delete` -> `Index`

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Views/MyPupilList/Index.cshtml
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Views/MyPupilList/Index.cshtml
@@ -91,7 +91,7 @@
 
                 <div class="govuk-grid-column-one-quarter">
                     <button asp-controller="@Routes.MyPupilList.DeleteMyPupilsController"
-                            asp-action="Delete"
+                            asp-action="@Routes.MyPupilList.DeleteMyPupilsControllerAction"
                             asp-route-pageNumber="@Model.PageNumber"
                             asp-route-sortField="@Model.SortField"
                             asp-route-sortDirection="@Model.SortDirection"


### PR DESCRIPTION
## 📌 Summary

Fix a broken link for `DeleteMyPupils`
Broken in #593 

## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:


## ✅ Checklist
- [x] Code compiles
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
