### PR TITLE
Fix: Make SearchOptionsBuilder transient avoiding stateful issues with multiple calls to SearchServices in MyPupils

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/Services/AggregatePupilsForMyPupils/AggregatePupilsForMyPupilsService.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/MyPupils/Application/Services/AggregatePupilsForMyPupils/AggregatePupilsForMyPupilsService.cs
@@ -84,7 +84,7 @@ internal sealed class AggregatePupilsForMyPupilsApplicationService : IAggregateP
 
         SearchIndexOptions npdIndexOptions = _searchIndexOptionsProvider.GetOptions("npd-upn");
 
-        NationalPupilDatabaseSearchByUniquePupilNumberResponse searchResponse =
+        NationalPupilDatabaseSearchByUniquePupilNumberResponse npdSearchResponse =
         await _npdSearchServiceAdaptor.HandleRequestAsync(
             new NationalPupilDatabaseSearchByUniquePupilNumberRequest()
             {
@@ -107,7 +107,7 @@ internal sealed class AggregatePupilsForMyPupilsApplicationService : IAggregateP
                 });
 
         IEnumerable<Pupil> allPupils =
-            (searchResponse.LearnerSearchResults?.Values.Select(_npdLearnerToPupilMapper.Map) ?? [])
+            (npdSearchResponse.LearnerSearchResults?.Values.Select(_npdLearnerToPupilMapper.Map) ?? [])
                 .Concat(pupilPremiumSearchResponse.LearnerSearchResults?.Values.Select(_pupilPremiumLearnerToPupilMapper.Map) ?? [])
                 // Deduplicate
                 .GroupBy(pupil => pupil.Identifier.Value)

--- a/DfE.GIAP.All/src/DfE.GIAP.Core/Search/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Core/Search/CompositionRoot.cs
@@ -35,7 +35,7 @@ public static class CompositionRoot
             .AddSearchOptions(configuration);
 
         services
-            .AddScoped<ISearchOptionsBuilder, SearchOptionsBuilder>();
+            .AddTransient<ISearchOptionsBuilder, SearchOptionsBuilder>();
 
         services.AddSingleton<IMapper<SearchCriteriaOptions, SearchCriteria>, SearchCriteriaOptionsToSearchCriteriaMapper>();
         // Register shared cognitive search and filter services.


### PR DESCRIPTION

## 📌 Summary

Bugfix - Builder is requested in the same request scope twice, appends `UPN` as SearchField, and fails the PP search, meaning all pupils are treated as not PupilPremium pupils, and, pupil premium pupils are not fetched and deduplicated.


## 🧪 Changes Made

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] docs – Documentation only changes
- [ ] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
