### PR TITLE
refactor: Upsert pupil selections reuse as PresentationService

### DIFF
--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/CompositionRoot.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/CompositionRoot.cs
@@ -17,6 +17,7 @@ using DfE.GIAP.Web.Features.MyPupils.Services.DeletePupils;
 using DfE.GIAP.Web.Features.MyPupils.Services.GetPupils;
 using DfE.GIAP.Web.Features.MyPupils.Services.GetPupils.Mapper;
 using DfE.GIAP.Web.Features.MyPupils.Services.GetSelectedPupilUpns;
+using DfE.GIAP.Web.Features.MyPupils.Services.UpsertSelectedPupils;
 using DfE.GIAP.Web.Shared.Serializer;
 using DfE.GIAP.Web.Shared.Session.Abstraction;
 using DfE.GIAP.Web.Shared.Session.Abstraction.Command;
@@ -50,16 +51,16 @@ public static class CompositionRoot
         services.AddOptions<MyPupilsMessagingOptions>();
         services.AddOptions<MyPupilSelectionOptions>();
 
-        // PresentationService
+        // PresentationServices
         services
             .AddSingleton<IMapper<MyPupilsModels, MyPupilsPresentationPupilModels>, MyPupilModelsToMyPupilsPresentationPupilModelMapper>()
             .AddSingleton<IMapper<MyPupilsModel, MyPupilsPresentationPupilModel>, MyPupilModelToMyPupilsPresentationPupilModelMapper>()
             .AddScoped<IMapper<MyPupilsPresentationResponse, MyPupilsViewModel>, MyPupilsPresentationResponseToMyPupilsViewModelMapper>()
             .AddScoped<IGetMyPupilsPresentationService, GetMyPupilsPresentationService>()
             .AddScoped<IGetSelectedPupilsUniquePupilNumbersPresentationService, GetSelectedPupilsUniquePupilNumbersPresentationService>()
+            .AddScoped<IUpsertSelectedPupilsIdentifiersPresentationService, UpsertSelectedPupilsPresentationService>()
             .AddScoped<IDeleteMyPupilsPresentationService, DeleteMyPupilsPresentationService>();
             
-
         // MessagingSink
         services
             .AddScoped<IMyPupilsMessageSink, MyPupilsTempDataMessageSink>()

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsPupilSelectionModeRequestDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsPupilSelectionModeRequestDto.cs
@@ -1,6 +1,6 @@
 ﻿namespace DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
 
-public enum MyPupilsFormSelectionModeRequestDto
+public enum MyPupilsPupilSelectionModeRequestDto
 {
     SelectAll,
     DeselectAll,

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsPupilSelectionsRequestDto.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/MyPupilsPupilSelectionsRequestDto.cs
@@ -2,7 +2,7 @@
 
 namespace DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
 
-public record MyPupilsFormStateRequestDto
+public record MyPupilsPupilSelectionsRequestDto
 {
     // TODO consider CustomModelBinding to SelectAllState, which is what should be used in Controller to pass down OR Mapper
     [FromForm]
@@ -16,19 +16,19 @@ public record MyPupilsFormStateRequestDto
     [FromForm]
     public List<string> CurrentPupils { get; set; } = [];
 
-    public MyPupilsFormSelectionModeRequestDto SelectAllState
+    public MyPupilsPupilSelectionModeRequestDto SelectAllState
     {
         get
         {
             if (SelectAll.HasValue && SelectAll.Value)
             {
-                return MyPupilsFormSelectionModeRequestDto.SelectAll;
+                return MyPupilsPupilSelectionModeRequestDto.SelectAll;
             }
             if (SelectAll.HasValue && !SelectAll.Value)
             {
-                return MyPupilsFormSelectionModeRequestDto.DeselectAll;
+                return MyPupilsPupilSelectionModeRequestDto.DeselectAll;
             }
-            return MyPupilsFormSelectionModeRequestDto.ManualSelection; ;
+            return MyPupilsPupilSelectionModeRequestDto.ManualSelection; ;
         }
     }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/UpdateMyPupilsController.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Controllers/UpdateForm/UpdateMyPupilsController.cs
@@ -33,13 +33,13 @@ public class UpdateMyPupilsController : Controller
     // Prevent browser-caching from back button presenting stale state
     [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
     [ValidateAntiForgeryToken]
-    public IActionResult Index(MyPupilsFormStateRequestDto formDto, MyPupilsQueryRequestDto query)
+    public IActionResult Index(MyPupilsPupilSelectionsRequestDto selectionsDto, MyPupilsQueryRequestDto query)
     {
         _logger.LogInformation("{Controller}.{Action} POST method called", nameof(UpdateMyPupilsController), nameof(Index));
 
         query ??= new();
 
-        if (formDto is null || !ModelState.IsValid)
+        if (selectionsDto is null || !ModelState.IsValid)
         {
             _myPupilsLogSink.AddMessage(
                 new MyPupilsMessage(
@@ -49,7 +49,7 @@ public class UpdateMyPupilsController : Controller
             return MyPupilsRedirectHelpers.RedirectToGetMyPupils(query);
         }
 
-        _updateMyPupilsSelectionsCommandHandler.Handle(formDto);
+        _updateMyPupilsSelectionsCommandHandler.Handle(selectionsDto);
 
         return MyPupilsRedirectHelpers.RedirectToGetMyPupils(query);
     }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/DeselectAllPupilsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/DeselectAllPupilsCommandHandler.cs
@@ -11,7 +11,7 @@ internal sealed class DeselectAllPupilsCommandHandler : IEvaluationHandler<Updat
             return HandlerResultValueTaskFactory.FailedWithNullArgument(nameof(input));
         }
 
-        if (input.UpdateRequest.SelectAllState != MyPupilsFormSelectionModeRequestDto.DeselectAll)
+        if (input.UpdateRequest.SelectAllState != MyPupilsPupilSelectionModeRequestDto.DeselectAll)
         {
             return HandlerResultValueTaskFactory.Skipped();
         }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/SelectAllPupilsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/Handlers/SelectAllPupilsCommandHandler.cs
@@ -11,7 +11,7 @@ internal sealed class SelectAllPupilsCommandHandler : IEvaluationHandler<UpdateM
             return HandlerResultValueTaskFactory.FailedWithNullArgument(nameof(input));
         }
 
-        if (input.UpdateRequest.SelectAllState != MyPupilsFormSelectionModeRequestDto.SelectAll)
+        if (input.UpdateRequest.SelectAllState != MyPupilsPupilSelectionModeRequestDto.SelectAll)
         {
             return HandlerResultValueTaskFactory.Skipped();
         }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/IUpdateMyPupilsPupilSelectionsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/IUpdateMyPupilsPupilSelectionsCommandHandler.cs
@@ -4,5 +4,5 @@ namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
 
 public interface IUpdateMyPupilsPupilSelectionsCommandHandler
 {
-    Task Handle(MyPupilsFormStateRequestDto request);
+    Task Handle(MyPupilsPupilSelectionsRequestDto selectionsDto);
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandler.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandler.cs
@@ -34,9 +34,9 @@ internal sealed class UpdateMyPupilsPupilSelectionsCommandHandler : IUpdateMyPup
         _selectionsSessionCacheKey = new(options.Value.SelectionsSessionKey);
     }
 
-    public async Task Handle(MyPupilsFormStateRequestDto formDto)
+    public async Task Handle(MyPupilsPupilSelectionsRequestDto selectionsDto)
     {
-        UpdateMyPupilsSelectionStateRequest updateRequest = new(formDto, _getPupilSelectionsProvider.GetPupilSelections());
+        UpdateMyPupilsSelectionStateRequest updateRequest = new(selectionsDto, _getPupilSelectionsProvider.GetPupilSelections());
 
         await _evaluator.EvaluateAsync(updateRequest);
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsSelectionStateRequest.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsSelectionStateRequest.cs
@@ -4,15 +4,15 @@ namespace DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
 
 public record UpdateMyPupilsSelectionStateRequest
 {
-    public UpdateMyPupilsSelectionStateRequest(MyPupilsFormStateRequestDto updateRequest, MyPupilsPupilSelectionState currentState)
+    public UpdateMyPupilsSelectionStateRequest(MyPupilsPupilSelectionsRequestDto selectionsDto, MyPupilsPupilSelectionState currentState)
     {
-        ArgumentNullException.ThrowIfNull(updateRequest);
-        UpdateRequest = updateRequest;
+        ArgumentNullException.ThrowIfNull(selectionsDto);
+        UpdateRequest = selectionsDto;
 
         ArgumentNullException.ThrowIfNull(currentState);
         State = currentState;
     }
 
-    public MyPupilsFormStateRequestDto UpdateRequest { get; init; }
+    public MyPupilsPupilSelectionsRequestDto UpdateRequest { get; init; }
     public MyPupilsPupilSelectionState State { get; init; }
 }

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Services/GetSelectedPupilUpns/GetSelectedPupilsUniquePupilNumbersPresentationService.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Services/GetSelectedPupilUpns/GetSelectedPupilsUniquePupilNumbersPresentationService.cs
@@ -1,5 +1,4 @@
-﻿using DfE.GIAP.Core.Common.Application;
-using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
+﻿using DfE.GIAP.Core.MyPupils.Application.UseCases.GetMyPupils;
 using DfE.GIAP.Web.Features.MyPupils.PupilSelection;
 using DfE.GIAP.Web.Features.MyPupils.PupilSelection.GetPupilSelections;
 

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Services/UpsertSelectedPupils/IUpsertSelectedPupilsIdentifiersPresentationService.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Services/UpsertSelectedPupils/IUpsertSelectedPupilsIdentifiersPresentationService.cs
@@ -1,0 +1,8 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+
+namespace DfE.GIAP.Web.Features.MyPupils.Services.UpsertSelectedPupils;
+
+public interface IUpsertSelectedPupilsIdentifiersPresentationService
+{
+    Task<List<string>> UpsertAsync(string userId, MyPupilsPupilSelectionsRequestDto? selectionsDto);
+}

--- a/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Services/UpsertSelectedPupils/UpsertSelectedPupilsPresentationService.cs
+++ b/DfE.GIAP.All/src/DfE.GIAP.Web/Features/MyPupils/Services/UpsertSelectedPupils/UpsertSelectedPupilsPresentationService.cs
@@ -1,0 +1,36 @@
+﻿using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
+using DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
+using DfE.GIAP.Web.Features.MyPupils.Services.GetSelectedPupilUpns;
+
+namespace DfE.GIAP.Web.Features.MyPupils.Services.UpsertSelectedPupils;
+
+internal sealed class UpsertSelectedPupilsPresentationService : IUpsertSelectedPupilsIdentifiersPresentationService
+{
+    private readonly IUpdateMyPupilsPupilSelectionsCommandHandler _updateMyPupilsPupilSelectionsCommandHandler;
+    private readonly IGetSelectedPupilsUniquePupilNumbersPresentationService _getSelectedPupilsPresentationHandler;
+
+    public UpsertSelectedPupilsPresentationService(
+        IUpdateMyPupilsPupilSelectionsCommandHandler updateMyPupilsPupilSelectionsCommandHandler,
+        IGetSelectedPupilsUniquePupilNumbersPresentationService getSelectedPupilsPresentationHandler)
+    {
+        ArgumentNullException.ThrowIfNull(updateMyPupilsPupilSelectionsCommandHandler);
+        _updateMyPupilsPupilSelectionsCommandHandler = updateMyPupilsPupilSelectionsCommandHandler;
+
+        ArgumentNullException.ThrowIfNull(getSelectedPupilsPresentationHandler);
+        _getSelectedPupilsPresentationHandler = getSelectedPupilsPresentationHandler;
+    }
+
+    public async Task<List<string>> UpsertAsync(string userId, MyPupilsPupilSelectionsRequestDto? selectionsDto)
+    {
+        if (selectionsDto != null)
+        {
+            await _updateMyPupilsPupilSelectionsCommandHandler.Handle(selectionsDto);
+        }
+
+        List<string> allSelectedPupils =
+            (await _getSelectedPupilsPresentationHandler.GetSelectedPupilsAsync(userId))
+                .ToList();
+
+        return allSelectedPupils;
+    }
+}

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/Controllers/UpdateMyPupilsControllerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/Controllers/UpdateMyPupilsControllerTests.cs
@@ -4,8 +4,6 @@ using DfE.GIAP.Web.Features.MyPupils.Controllers.UpdateForm;
 using DfE.GIAP.Web.Features.MyPupils.Messaging;
 using DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
-using Xunit;
 
 namespace DfE.GIAP.Web.Tests.Features.MyPupils.Controllers;
 public sealed class UpdateMyPupilsControllerTests
@@ -72,7 +70,7 @@ public sealed class UpdateMyPupilsControllerTests
         Assert.Equal("UpdateMyPupilsController.Index POST method called", loggerFake.Logs.Single());
         ActionResultAssertionHelpers.AssertRedirectToGetMyPupils(response);
 
-        handlerMock.Verify(t => t.Handle(It.IsAny<MyPupilsFormStateRequestDto>()), Times.Never);
+        handlerMock.Verify(t => t.Handle(It.IsAny<MyPupilsPupilSelectionsRequestDto>()), Times.Never);
     }
 
     [Fact]
@@ -99,7 +97,7 @@ public sealed class UpdateMyPupilsControllerTests
             SortField = "any_field"
         };
 
-        MyPupilsFormStateRequestDto request = new();
+        MyPupilsPupilSelectionsRequestDto request = new();
 
         IActionResult response = sut.Index(request, query);
 
@@ -109,7 +107,7 @@ public sealed class UpdateMyPupilsControllerTests
 
         handlerMock.Verify((handler)
             => handler.Handle(
-                It.Is<MyPupilsFormStateRequestDto>(
+                It.Is<MyPupilsPupilSelectionsRequestDto>(
                     (req) => ReferenceEquals(request, req))), Times.Once);
 
         messageSinkMock.Verify(t => t.AddMessage(It.IsAny<MyPupilsMessage>()), Times.Never);

--- a/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandlerTests.cs
+++ b/DfE.GIAP.All/tests/DfE.GIAP.Web.Tests/Features/MyPupils/PupilSelection/UpdatePupilSelections/UpdateMyPupilsPupilSelectionsCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using DfE.GIAP.Web.Features.MyPupils.PupilSelection.GetPupilSelections;
 using DfE.GIAP.Web.Features.MyPupils.PupilSelection.Options;
 using DfE.GIAP.Web.Features.MyPupils.PupilSelection.UpdatePupilSelections;
 using DfE.GIAP.Web.Shared.Session.Abstraction;
-using HandlebarsDotNet;
 using Microsoft.Extensions.Options;
 
 namespace DfE.GIAP.Web.Tests.Features.MyPupils.PupilSelection.UpdatePupilSelections;
@@ -132,7 +131,7 @@ public sealed class UpdateMyPupilsPupilSelectionsCommandHandlerTests
                 evaluatorMock.Object,
                 options);
 
-        MyPupilsFormStateRequestDto request = new();
+        MyPupilsPupilSelectionsRequestDto request = new();
 
         // Act
         await sut.Handle(request);


### PR DESCRIPTION
## 📌 Summary

Register a presentation service to deal with upserting pupil selections, and returning back the identifiers.

## 🧪 Changes Made

- [ ] feat – New feature
- [ ] fix – Bug fix
- [ ] docs – Documentation only changes
- [x] refactor – Code change that neither fixes a bug nor adds a feature
- [ ] chore – Maintenance tasks (e.g., build, config, dependencies)
- [ ] pipeline – CI/CD or workflow updates
- [ ] tests – Adding or updating tests
- [ ] other – Please describe:

## ✅ Checklist
- [x] Code compiles
- [ ] Tests added or updated
- [ ] Documentation updated (if not needed cross out)
- [x] CI pass (tests, codecov, lint)
